### PR TITLE
Implement POST /path?create=true for explicit repository creation

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,6 +70,8 @@ func setupMux() *goji.Mux {
 	mux.HandleFunc(pat.Post("/:repo/:type/:name"), SaveBlob)
 	mux.HandleFunc(pat.Delete("/:type/:name"), DeleteBlob)
 	mux.HandleFunc(pat.Delete("/:repo/:type/:name"), DeleteBlob)
+	mux.HandleFunc(pat.Post("/"), CreateRepo)
+	mux.HandleFunc(pat.Post("/:repo"), CreateRepo)
 
 	return mux
 }


### PR DESCRIPTION
Legacy code which created repo on first "POST /keys/foo" remains, so
restic clients <= v0.3.3 continue working.