### PR TITLE
Create hash directory in SaveBlob if isHashed

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -233,6 +233,18 @@ func SaveBlob(w http.ResponseWriter, r *http.Request) {
 
 	if isHashed(dir) {
 		name = filepath.Join(name[:2], name)
+
+		hashDir := filepath.Join(repo, dir, name[:2])
+		if _, err := os.Stat(hashDir); os.IsNotExist(err) {
+			if err := os.Mkdir(hashDir, 0700); err != nil {
+				if config.debug {
+					log.Print(err)
+				}
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
+			}
+		}
+
 	}
 	path := filepath.Join(repo, dir, name)
 


### PR DESCRIPTION
Hi, got errors from rest server when setting a repo name rest:http://user:pass@127.0.0.1:8000/XXX
the "hash" dir was not created.