### PR TITLE
Allow the $OPTIONS env var when using docker image

### DIFF
--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -18,4 +18,4 @@ else
     rm -f $PASSWORD_FILE
 fi
 
-rest-server --listen ":80" --path $DATA_DIRECTORY
+rest-server --listen ":80" $OPTIONS --path $DATA_DIRECTORY


### PR DESCRIPTION
Example:

`docker run -e OPTIONS="--append-only" restic/rest-server`