### PR TITLE
add example rc scripts for OpenBSD and FreeBSD

### DIFF
--- a/examples/bsd/freebsd
+++ b/examples/bsd/freebsd
@@ -17,7 +17,6 @@ datadir="/backups"
 restserver_start()
 {
 	rest-server --path $datadir				\
-		--listen 10.0.1.6:8000				\
 		--private-repos					\
 		--tls						\
 		--tls-cert "/etc/ssl/rest-server.crt"		\

--- a/examples/bsd/freebsd
+++ b/examples/bsd/freebsd
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+. /etc/rc.subr
+
+name=restserver
+rcvar=restserver_enable
+
+start_cmd="${name}_start"
+stop_cmd=":"
+
+load_rc_config $name
+: ${restserver_enable:=no}
+: ${restserver_msg="Nothing started."}
+
+datadir="/backups"
+
+restserver_start()
+{
+	rest-server --path $datadir				\
+		--listen 10.0.1.6:8000				\
+		--private-repos					\
+		--tls						\
+		--tls-cert "/etc/ssl/rest-server.crt"		\
+		--tls-key "/etc/ssl/private/rest-server.key"	&
+}
+
+run_rc_command "$1"

--- a/examples/bsd/openbsd
+++ b/examples/bsd/openbsd
@@ -1,0 +1,14 @@
+#!/bin/ksh
+#
+# $OpenBSD: $
+
+daemon="/usr/local/bin/rest-server"
+daemon_flags="--path /var/restic"
+daemon_user="_restic"
+
+. /etc/rc.d/rc.subr
+
+rc_bg=YES
+rc_reload=NO
+
+rc_cmd $1


### PR DESCRIPTION
The OpenBSD rc script will be packaged with the [rest-server](https://github.com/jasperla/openbsd-wip/blob/master/sysutils/rest-server/pkg/rest_server.rc) port once it is imported (hopefully this week).
