### PR TITLE
Add --version flag to print version and exit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Flags:
       --tls                 turn on TLS support
       --tls-cert string     TLS certificate path
       --tls-key string      TLS key path
+  -V, --version             show version and quit
 
 ```
 

--- a/cmd/rest-server/main.go
+++ b/cmd/rest-server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -20,6 +21,8 @@ var cmdRoot = &cobra.Command{
 	SilenceErrors: true,
 	SilenceUsage:  true,
 	RunE:          runRoot,
+	// Use this instead of other --version code when the Cobra dependency can be updated.
+	//Version:       fmt.Sprintf("rest-server %s compiled with %v on %v/%v\n", version, runtime.Version(), runtime.GOOS, runtime.GOARCH),
 }
 
 func init() {
@@ -35,6 +38,7 @@ func init() {
 	flags.BoolVar(&restserver.Config.AppendOnly, "append-only", restserver.Config.AppendOnly, "enable append only mode")
 	flags.BoolVar(&restserver.Config.PrivateRepos, "private-repos", restserver.Config.PrivateRepos, "users can only access their private repo")
 	flags.BoolVar(&restserver.Config.Prometheus, "prometheus", restserver.Config.Prometheus, "enable Prometheus metrics")
+	flags.BoolVarP(&restserver.Config.Version, "version", "V", restserver.Config.Version, "output version and exit")
 }
 
 var version = "manually"
@@ -61,9 +65,13 @@ func tlsSettings() (bool, string, string, error) {
 }
 
 func runRoot(cmd *cobra.Command, args []string) error {
+	if restserver.Config.Version {
+		fmt.Printf("rest-server %s compiled with %v on %v/%v\n", version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+		os.Exit(0)
+	}
+
 	log.SetFlags(0)
 
-	log.Printf("rest-server %s compiled with %v on %v/%v\n", version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 	log.Printf("Data directory: %s", restserver.Config.Path)
 
 	if restserver.Config.CPUProfile != "" {

--- a/mux.go
+++ b/mux.go
@@ -25,6 +25,7 @@ var Config = struct {
 	PrivateRepos bool
 	Prometheus   bool
 	Debug        bool
+	Version      bool
 }{
 	Path:       "/tmp/restic",
 	Listen:     ":8000",


### PR DESCRIPTION
This change moves version output to a dedicated `--version`/`-V` option, which is more conventional and in line with both restic and rclone.

For now it's done with a regular flag, but once there's a new version of spf13/cobra we can use Cobra's built-in support for `--version` (the code for this is included in this commit, but commented out).