### PR TITLE
Refactor handlers: make Config not global

### DIFF
--- a/cmd/rest-server/main_test.go
+++ b/cmd/rest-server/main_test.go
@@ -38,13 +38,13 @@ func TestTLSSettings(t *testing.T) {
 	for _, test := range tests {
 
 		t.Run("", func(t *testing.T) {
-			// defer func() { restserver.Config = defaultConfig }()
+			// defer func() { restserver.Server = defaultConfig }()
 			if test.passed.Path != "" {
-				repoPath = test.passed.Path
+				server.Path = test.passed.Path
 			}
-			useTLS = test.passed.TLS
-			tlsKey = test.passed.TLSKey
-			tlsCert = test.passed.TLSCert
+			server.TLS = test.passed.TLS
+			server.TLSKey = test.passed.TLSKey
+			server.TLSCert = test.passed.TLSCert
 
 			gotTLS, gotKey, gotCert, err := tlsSettings()
 			if err != nil && !test.expected.Error {
@@ -82,13 +82,13 @@ func TestGetHandler(t *testing.T) {
 	defer os.Remove(dir)
 
 	// With NoAuth = false and no .htpasswd
-	_, err = getHandler(restserver.Config{Path: dir})
+	_, err = getHandler(restserver.Server{Path: dir})
 	if err == nil {
 		t.Errorf("NoAuth=false: expected error, got nil")
 	}
 
 	// With NoAuth = true and no .htpasswd
-	_, err = getHandler(restserver.Config{NoAuth: true, Path: dir})
+	_, err = getHandler(restserver.Server{NoAuth: true, Path: dir})
 	if err != nil {
 		t.Errorf("NoAuth=true: expected no error, got %v", err)
 	}
@@ -102,7 +102,7 @@ func TestGetHandler(t *testing.T) {
 	defer os.Remove(htpasswd)
 
 	// With NoAuth = false and with .htpasswd
-	_, err = getHandler(restserver.Config{Path: dir})
+	_, err = getHandler(restserver.Server{Path: dir})
 	if err != nil {
 		t.Errorf("NoAuth=false with .htpasswd: expected no error, got %v", err)
 	}

--- a/cmd/rest-server/main_test.go
+++ b/cmd/rest-server/main_test.go
@@ -35,17 +35,16 @@ func TestTLSSettings(t *testing.T) {
 		{passed{Path: "/tmp", TLS: false, TLSCert: "/etc/restic/cert"}, expected{"", "", true}},
 	}
 
-	defaultConfig := restserver.Config
 	for _, test := range tests {
 
 		t.Run("", func(t *testing.T) {
-			defer func() { restserver.Config = defaultConfig }()
+			// defer func() { restserver.Config = defaultConfig }()
 			if test.passed.Path != "" {
-				restserver.Config.Path = test.passed.Path
+				repoPath = test.passed.Path
 			}
-			restserver.Config.TLS = test.passed.TLS
-			restserver.Config.TLSKey = test.passed.TLSKey
-			restserver.Config.TLSCert = test.passed.TLSCert
+			useTLS = test.passed.TLS
+			tlsKey = test.passed.TLSKey
+			tlsCert = test.passed.TLSCert
 
 			gotTLS, gotKey, gotCert, err := tlsSettings()
 			if err != nil && !test.expected.Error {
@@ -76,27 +75,20 @@ func TestTLSSettings(t *testing.T) {
 }
 
 func TestGetHandler(t *testing.T) {
-	// Save and restore config
-	defaultConfig := restserver.Config
-	defer func() { restserver.Config = defaultConfig }()
-
 	dir, err := ioutil.TempDir("", "rest-server-test")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.Remove(dir)
-	restserver.Config.Path = dir
 
 	// With NoAuth = false and no .htpasswd
-	restserver.Config.NoAuth = false // default
-	_, err = getHandler()
+	_, err = getHandler(restserver.Config{Path: dir})
 	if err == nil {
 		t.Errorf("NoAuth=false: expected error, got nil")
 	}
 
 	// With NoAuth = true and no .htpasswd
-	restserver.Config.NoAuth = true
-	_, err = getHandler()
+	_, err = getHandler(restserver.Config{NoAuth: true, Path: dir})
 	if err != nil {
 		t.Errorf("NoAuth=true: expected no error, got %v", err)
 	}
@@ -110,8 +102,7 @@ func TestGetHandler(t *testing.T) {
 	defer os.Remove(htpasswd)
 
 	// With NoAuth = false and with .htpasswd
-	restserver.Config.NoAuth = false // default
-	_, err = getHandler()
+	_, err = getHandler(restserver.Config{Path: dir})
 	if err != nil {
 		t.Errorf("NoAuth=false with .htpasswd: expected no error, got %v", err)
 	}

--- a/handlers.go
+++ b/handlers.go
@@ -20,7 +20,23 @@ import (
 	"goji.io/pat"
 )
 
-func isHashed(dir string) bool {
+// Config determines how a Mux's handlers behave.
+type Config struct {
+	Path         string
+	Listen       string
+	Log          string
+	CPUProfile   string
+	TLSKey       string
+	TLSCert      string
+	TLS          bool
+	NoAuth       bool
+	AppendOnly   bool
+	PrivateRepos bool
+	Prometheus   bool
+	Debug        bool
+}
+
+func (c Config) isHashed(dir string) bool {
 	return dir == "data"
 }
 
@@ -39,7 +55,7 @@ func valid(name string) bool {
 
 var validTypes = []string{"data", "index", "keys", "locks", "snapshots", "config"}
 
-func isValidType(name string) bool {
+func (c Config) isValidType(name string) bool {
 	for _, tpe := range validTypes {
 		if name == tpe {
 			return true
@@ -69,8 +85,8 @@ func join(base string, names ...string) (string, error) {
 	return filepath.Join(clean...), nil
 }
 
-// getRepo returns the repository location, relative to Config.Path.
-func getRepo(r *http.Request) string {
+// getRepo returns the repository location, relative to c.Path.
+func (c Config) getRepo(r *http.Request) string {
 	if strings.HasPrefix(fmt.Sprintf("%s", middleware.Pattern(r.Context())), "/:repo") {
 		return pat.Param(r, "repo")
 	}
@@ -79,32 +95,32 @@ func getRepo(r *http.Request) string {
 }
 
 // getPath returns the path for a file type in the repo.
-func getPath(r *http.Request, fileType string) (string, error) {
-	if !isValidType(fileType) {
+func (c Config) getPath(r *http.Request, fileType string) (string, error) {
+	if !c.isValidType(fileType) {
 		return "", errors.New("invalid file type")
 	}
-	return join(Config.Path, getRepo(r), fileType)
+	return join(c.Path, c.getRepo(r), fileType)
 }
 
 // getFilePath returns the path for a file in the repo.
-func getFilePath(r *http.Request, fileType, name string) (string, error) {
-	if !isValidType(fileType) {
+func (c Config) getFilePath(r *http.Request, fileType, name string) (string, error) {
+	if !c.isValidType(fileType) {
 		return "", errors.New("invalid file type")
 	}
 
-	if isHashed(fileType) {
+	if c.isHashed(fileType) {
 		if len(name) < 2 {
 			return "", errors.New("file name is too short")
 		}
 
-		return join(Config.Path, getRepo(r), fileType, name[:2], name)
+		return join(c.Path, c.getRepo(r), fileType, name[:2], name)
 	}
 
-	return join(Config.Path, getRepo(r), fileType, name)
+	return join(c.Path, c.getRepo(r), fileType, name)
 }
 
 // getUser returns the username from the request, or an empty string if none.
-func getUser(r *http.Request) string {
+func (c Config) getUser(r *http.Request) string {
 	username, _, ok := r.BasicAuth()
 	if !ok {
 		return ""
@@ -113,10 +129,10 @@ func getUser(r *http.Request) string {
 }
 
 // getMetricLabels returns the prometheus labels from the request.
-func getMetricLabels(r *http.Request) prometheus.Labels {
+func (c Config) getMetricLabels(r *http.Request) prometheus.Labels {
 	labels := prometheus.Labels{
-		"user": getUser(r),
-		"repo": getRepo(r),
+		"user": c.getUser(r),
+		"repo": c.getRepo(r),
 		"type": pat.Param(r, "type"),
 	}
 	return labels
@@ -134,14 +150,14 @@ func isUserPath(username, path string) bool {
 
 // AuthHandler wraps h with a http.HandlerFunc that performs basic authentication against the user/passwords pairs
 // stored in f and returns the http.HandlerFunc.
-func AuthHandler(f *HtpasswdFile, h http.Handler) http.HandlerFunc {
+func (c Config) AuthHandler(f *HtpasswdFile, h http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		username, password, ok := r.BasicAuth()
 		if !ok || !f.Validate(username, password) {
 			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 			return
 		}
-		if Config.PrivateRepos && !isUserPath(username, r.URL.Path) {
+		if c.PrivateRepos && !isUserPath(username, r.URL.Path) {
 			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 			return
 		}
@@ -150,11 +166,11 @@ func AuthHandler(f *HtpasswdFile, h http.Handler) http.HandlerFunc {
 }
 
 // CheckConfig checks whether a configuration exists.
-func CheckConfig(w http.ResponseWriter, r *http.Request) {
-	if Config.Debug {
+func (c Config) CheckConfig(w http.ResponseWriter, r *http.Request) {
+	if c.Debug {
 		log.Println("CheckConfig()")
 	}
-	cfg, err := getPath(r, "config")
+	cfg, err := c.getPath(r, "config")
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
@@ -162,7 +178,7 @@ func CheckConfig(w http.ResponseWriter, r *http.Request) {
 
 	st, err := os.Stat(cfg)
 	if err != nil {
-		if Config.Debug {
+		if c.Debug {
 			log.Print(err)
 		}
 		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
@@ -173,11 +189,11 @@ func CheckConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 // GetConfig allows for a config to be retrieved.
-func GetConfig(w http.ResponseWriter, r *http.Request) {
-	if Config.Debug {
+func (c Config) GetConfig(w http.ResponseWriter, r *http.Request) {
+	if c.Debug {
 		log.Println("GetConfig()")
 	}
-	cfg, err := getPath(r, "config")
+	cfg, err := c.getPath(r, "config")
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
@@ -185,7 +201,7 @@ func GetConfig(w http.ResponseWriter, r *http.Request) {
 
 	bytes, err := ioutil.ReadFile(cfg)
 	if err != nil {
-		if Config.Debug {
+		if c.Debug {
 			log.Print(err)
 		}
 		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
@@ -196,11 +212,11 @@ func GetConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 // SaveConfig allows for a config to be saved.
-func SaveConfig(w http.ResponseWriter, r *http.Request) {
-	if Config.Debug {
+func (c Config) SaveConfig(w http.ResponseWriter, r *http.Request) {
+	if c.Debug {
 		log.Println("SaveConfig()")
 	}
-	cfg, err := getPath(r, "config")
+	cfg, err := c.getPath(r, "config")
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
@@ -208,7 +224,7 @@ func SaveConfig(w http.ResponseWriter, r *http.Request) {
 
 	f, err := os.OpenFile(cfg, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0600)
 	if err != nil && os.IsExist(err) {
-		if Config.Debug {
+		if c.Debug {
 			log.Print(err)
 		}
 		http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
@@ -217,7 +233,7 @@ func SaveConfig(w http.ResponseWriter, r *http.Request) {
 
 	_, err = io.Copy(f, r.Body)
 	if err != nil {
-		if Config.Debug {
+		if c.Debug {
 			log.Print(err)
 		}
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -234,24 +250,24 @@ func SaveConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 // DeleteConfig removes a config.
-func DeleteConfig(w http.ResponseWriter, r *http.Request) {
-	if Config.Debug {
+func (c Config) DeleteConfig(w http.ResponseWriter, r *http.Request) {
+	if c.Debug {
 		log.Println("DeleteConfig()")
 	}
 
-	if Config.AppendOnly {
+	if c.AppendOnly {
 		http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
 		return
 	}
 
-	cfg, err := getPath(r, "config")
+	cfg, err := c.getPath(r, "config")
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 
 	if err := os.Remove(cfg); err != nil {
-		if Config.Debug {
+		if c.Debug {
 			log.Print(err)
 		}
 		if os.IsNotExist(err) {
@@ -269,26 +285,26 @@ const (
 )
 
 // ListBlobs lists all blobs of a given type in an arbitrary order.
-func ListBlobs(w http.ResponseWriter, r *http.Request) {
-	if Config.Debug {
+func (c Config) ListBlobs(w http.ResponseWriter, r *http.Request) {
+	if c.Debug {
 		log.Println("ListBlobs()")
 	}
 
 	switch r.Header.Get("Accept") {
 	case mimeTypeAPIV2:
-		ListBlobsV2(w, r)
+		c.ListBlobsV2(w, r)
 	default:
-		ListBlobsV1(w, r)
+		c.ListBlobsV1(w, r)
 	}
 }
 
 // ListBlobsV1 lists all blobs of a given type in an arbitrary order.
-func ListBlobsV1(w http.ResponseWriter, r *http.Request) {
-	if Config.Debug {
+func (c Config) ListBlobsV1(w http.ResponseWriter, r *http.Request) {
+	if c.Debug {
 		log.Println("ListBlobsV1()")
 	}
 	fileType := pat.Param(r, "type")
-	path, err := getPath(r, fileType)
+	path, err := c.getPath(r, fileType)
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
@@ -296,7 +312,7 @@ func ListBlobsV1(w http.ResponseWriter, r *http.Request) {
 
 	items, err := ioutil.ReadDir(path)
 	if err != nil {
-		if Config.Debug {
+		if c.Debug {
 			log.Print(err)
 		}
 		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
@@ -305,12 +321,12 @@ func ListBlobsV1(w http.ResponseWriter, r *http.Request) {
 
 	var names []string
 	for _, i := range items {
-		if isHashed(fileType) {
+		if c.isHashed(fileType) {
 			subpath := filepath.Join(path, i.Name())
 			var subitems []os.FileInfo
 			subitems, err = ioutil.ReadDir(subpath)
 			if err != nil {
-				if Config.Debug {
+				if c.Debug {
 					log.Print(err)
 				}
 				http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
@@ -326,7 +342,7 @@ func ListBlobsV1(w http.ResponseWriter, r *http.Request) {
 
 	data, err := json.Marshal(names)
 	if err != nil {
-		if Config.Debug {
+		if c.Debug {
 			log.Print(err)
 		}
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -344,12 +360,12 @@ type Blob struct {
 }
 
 // ListBlobsV2 lists all blobs of a given type, together with their sizes, in an arbitrary order.
-func ListBlobsV2(w http.ResponseWriter, r *http.Request) {
-	if Config.Debug {
+func (c Config) ListBlobsV2(w http.ResponseWriter, r *http.Request) {
+	if c.Debug {
 		log.Println("ListBlobsV2()")
 	}
 	fileType := pat.Param(r, "type")
-	path, err := getPath(r, fileType)
+	path, err := c.getPath(r, fileType)
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
@@ -357,7 +373,7 @@ func ListBlobsV2(w http.ResponseWriter, r *http.Request) {
 
 	items, err := ioutil.ReadDir(path)
 	if err != nil {
-		if Config.Debug {
+		if c.Debug {
 			log.Print(err)
 		}
 		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
@@ -366,12 +382,12 @@ func ListBlobsV2(w http.ResponseWriter, r *http.Request) {
 
 	var blobs []Blob
 	for _, i := range items {
-		if isHashed(fileType) {
+		if c.isHashed(fileType) {
 			subpath := filepath.Join(path, i.Name())
 			var subitems []os.FileInfo
 			subitems, err = ioutil.ReadDir(subpath)
 			if err != nil {
-				if Config.Debug {
+				if c.Debug {
 					log.Print(err)
 				}
 				http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
@@ -387,7 +403,7 @@ func ListBlobsV2(w http.ResponseWriter, r *http.Request) {
 
 	data, err := json.Marshal(blobs)
 	if err != nil {
-		if Config.Debug {
+		if c.Debug {
 			log.Print(err)
 		}
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -399,12 +415,12 @@ func ListBlobsV2(w http.ResponseWriter, r *http.Request) {
 }
 
 // CheckBlob tests whether a blob exists.
-func CheckBlob(w http.ResponseWriter, r *http.Request) {
-	if Config.Debug {
+func (c Config) CheckBlob(w http.ResponseWriter, r *http.Request) {
+	if c.Debug {
 		log.Println("CheckBlob()")
 	}
 
-	path, err := getFilePath(r, pat.Param(r, "type"), pat.Param(r, "name"))
+	path, err := c.getFilePath(r, pat.Param(r, "type"), pat.Param(r, "name"))
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
@@ -412,7 +428,7 @@ func CheckBlob(w http.ResponseWriter, r *http.Request) {
 
 	st, err := os.Stat(path)
 	if err != nil {
-		if Config.Debug {
+		if c.Debug {
 			log.Print(err)
 		}
 		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
@@ -423,12 +439,12 @@ func CheckBlob(w http.ResponseWriter, r *http.Request) {
 }
 
 // GetBlob retrieves a blob from the repository.
-func GetBlob(w http.ResponseWriter, r *http.Request) {
-	if Config.Debug {
+func (c Config) GetBlob(w http.ResponseWriter, r *http.Request) {
+	if c.Debug {
 		log.Println("GetBlob()")
 	}
 
-	path, err := getFilePath(r, pat.Param(r, "type"), pat.Param(r, "name"))
+	path, err := c.getFilePath(r, pat.Param(r, "type"), pat.Param(r, "name"))
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
@@ -436,7 +452,7 @@ func GetBlob(w http.ResponseWriter, r *http.Request) {
 
 	file, err := os.Open(path)
 	if err != nil {
-		if Config.Debug {
+		if c.Debug {
 			log.Print(err)
 		}
 		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
@@ -451,20 +467,20 @@ func GetBlob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if Config.Prometheus {
-		labels := getMetricLabels(r)
+	if c.Prometheus {
+		labels := c.getMetricLabels(r)
 		metricBlobReadTotal.With(labels).Inc()
 		metricBlobReadBytesTotal.With(labels).Add(float64(wc.Count()))
 	}
 }
 
 // SaveBlob saves a blob to the repository.
-func SaveBlob(w http.ResponseWriter, r *http.Request) {
-	if Config.Debug {
+func (c Config) SaveBlob(w http.ResponseWriter, r *http.Request) {
+	if c.Debug {
 		log.Println("SaveBlob()")
 	}
 
-	path, err := getFilePath(r, pat.Param(r, "type"), pat.Param(r, "name"))
+	path, err := c.getFilePath(r, pat.Param(r, "type"), pat.Param(r, "name"))
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
@@ -488,7 +504,7 @@ func SaveBlob(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		if Config.Debug {
+		if c.Debug {
 			log.Print(err)
 		}
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -499,7 +515,7 @@ func SaveBlob(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		_ = tf.Close()
 		_ = os.Remove(path)
-		if Config.Debug {
+		if c.Debug {
 			log.Print(err)
 		}
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
@@ -509,7 +525,7 @@ func SaveBlob(w http.ResponseWriter, r *http.Request) {
 	if err := tf.Sync(); err != nil {
 		_ = tf.Close()
 		_ = os.Remove(path)
-		if Config.Debug {
+		if c.Debug {
 			log.Print(err)
 		}
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -518,39 +534,39 @@ func SaveBlob(w http.ResponseWriter, r *http.Request) {
 
 	if err := tf.Close(); err != nil {
 		_ = os.Remove(path)
-		if Config.Debug {
+		if c.Debug {
 			log.Print(err)
 		}
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 
-	if Config.Prometheus {
-		labels := getMetricLabels(r)
+	if c.Prometheus {
+		labels := c.getMetricLabels(r)
 		metricBlobWriteTotal.With(labels).Inc()
 		metricBlobWriteBytesTotal.With(labels).Add(float64(written))
 	}
 }
 
 // DeleteBlob deletes a blob from the repository.
-func DeleteBlob(w http.ResponseWriter, r *http.Request) {
-	if Config.Debug {
+func (c Config) DeleteBlob(w http.ResponseWriter, r *http.Request) {
+	if c.Debug {
 		log.Println("DeleteBlob()")
 	}
 
-	if Config.AppendOnly && pat.Param(r, "type") != "locks" {
+	if c.AppendOnly && pat.Param(r, "type") != "locks" {
 		http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
 		return
 	}
 
-	path, err := getFilePath(r, pat.Param(r, "type"), pat.Param(r, "name"))
+	path, err := c.getFilePath(r, pat.Param(r, "type"), pat.Param(r, "name"))
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 
 	var size int64
-	if Config.Prometheus {
+	if c.Prometheus {
 		stat, err := os.Stat(path)
 		if err != nil {
 			size = stat.Size()
@@ -558,7 +574,7 @@ func DeleteBlob(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := os.Remove(path); err != nil {
-		if Config.Debug {
+		if c.Debug {
 			log.Print(err)
 		}
 		if os.IsNotExist(err) {
@@ -569,20 +585,20 @@ func DeleteBlob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if Config.Prometheus {
-		labels := getMetricLabels(r)
+	if c.Prometheus {
+		labels := c.getMetricLabels(r)
 		metricBlobDeleteTotal.With(labels).Inc()
 		metricBlobDeleteBytesTotal.With(labels).Add(float64(size))
 	}
 }
 
 // CreateRepo creates repository directories.
-func CreateRepo(w http.ResponseWriter, r *http.Request) {
-	if Config.Debug {
+func (c Config) CreateRepo(w http.ResponseWriter, r *http.Request) {
+	if c.Debug {
 		log.Println("CreateRepo()")
 	}
 
-	repo, err := join(Config.Path, getRepo(r))
+	repo, err := join(c.Path, c.getRepo(r))
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -230,7 +230,7 @@ func TestResticHandler(t *testing.T) {
 	}()
 
 	// set append-only mode and configure path
-	mux := NewHandler(Config{
+	mux := NewHandler(Server{
 		AppendOnly: true,
 		Path:       tempdir,
 	})

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -229,11 +229,11 @@ func TestResticHandler(t *testing.T) {
 		}
 	}()
 
-	// globally set append-only mode and configure path
-	Config.AppendOnly = true
-	Config.Path = tempdir
-
-	mux := NewMux()
+	// set append-only mode and configure path
+	mux := NewHandler(Config{
+		AppendOnly: true,
+		Path:       tempdir,
+	})
 
 	// create the repo
 	checkRequest(t, mux.ServeHTTP,

--- a/mux.go
+++ b/mux.go
@@ -12,7 +12,7 @@ import (
 	"goji.io/pat"
 )
 
-func (c Config) debugHandler(next http.Handler) http.Handler {
+func (s Server) debugHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			log.Printf("%s %s", r.Method, r.URL)
@@ -20,8 +20,8 @@ func (c Config) debugHandler(next http.Handler) http.Handler {
 		})
 }
 
-func (c Config) logHandler(next http.Handler) http.Handler {
-	accessLog, err := os.OpenFile(c.Log, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+func (s Server) logHandler(next http.Handler) http.Handler {
+	accessLog, err := os.OpenFile(s.Log, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
 		log.Fatalf("error: %v", err)
 	}
@@ -30,42 +30,42 @@ func (c Config) logHandler(next http.Handler) http.Handler {
 }
 
 // NewHandler returns the master HTTP multiplexer/router.
-func NewHandler(config Config) *goji.Mux {
+func NewHandler(server Server) *goji.Mux {
 	mux := goji.NewMux()
 
-	if config.Debug {
-		mux.Use(config.debugHandler)
+	if server.Debug {
+		mux.Use(server.debugHandler)
 	}
 
-	if config.Log != "" {
-		mux.Use(config.logHandler)
+	if server.Log != "" {
+		mux.Use(server.logHandler)
 	}
 
-	if config.Prometheus {
+	if server.Prometheus {
 		mux.Handle(pat.Get("/metrics"), promhttp.Handler())
 	}
 
-	mux.HandleFunc(pat.Head("/config"), config.CheckConfig)
-	mux.HandleFunc(pat.Head("/:repo/config"), config.CheckConfig)
-	mux.HandleFunc(pat.Get("/config"), config.GetConfig)
-	mux.HandleFunc(pat.Get("/:repo/config"), config.GetConfig)
-	mux.HandleFunc(pat.Post("/config"), config.SaveConfig)
-	mux.HandleFunc(pat.Post("/:repo/config"), config.SaveConfig)
-	mux.HandleFunc(pat.Delete("/config"), config.DeleteConfig)
-	mux.HandleFunc(pat.Delete("/:repo/config"), config.DeleteConfig)
-	mux.HandleFunc(pat.Get("/:type/"), config.ListBlobs)
-	mux.HandleFunc(pat.Get("/:repo/:type/"), config.ListBlobs)
-	mux.HandleFunc(pat.Head("/:type/:name"), config.CheckBlob)
-	mux.HandleFunc(pat.Head("/:repo/:type/:name"), config.CheckBlob)
-	mux.HandleFunc(pat.Get("/:type/:name"), config.GetBlob)
-	mux.HandleFunc(pat.Get("/:repo/:type/:name"), config.GetBlob)
-	mux.HandleFunc(pat.Post("/:type/:name"), config.SaveBlob)
-	mux.HandleFunc(pat.Post("/:repo/:type/:name"), config.SaveBlob)
-	mux.HandleFunc(pat.Delete("/:type/:name"), config.DeleteBlob)
-	mux.HandleFunc(pat.Delete("/:repo/:type/:name"), config.DeleteBlob)
-	mux.HandleFunc(pat.Post("/"), config.CreateRepo)
-	mux.HandleFunc(pat.Post("/:repo"), config.CreateRepo)
-	mux.HandleFunc(pat.Post("/:repo/"), config.CreateRepo)
+	mux.HandleFunc(pat.Head("/config"), server.CheckConfig)
+	mux.HandleFunc(pat.Head("/:repo/config"), server.CheckConfig)
+	mux.HandleFunc(pat.Get("/config"), server.GetConfig)
+	mux.HandleFunc(pat.Get("/:repo/config"), server.GetConfig)
+	mux.HandleFunc(pat.Post("/config"), server.SaveConfig)
+	mux.HandleFunc(pat.Post("/:repo/config"), server.SaveConfig)
+	mux.HandleFunc(pat.Delete("/config"), server.DeleteConfig)
+	mux.HandleFunc(pat.Delete("/:repo/config"), server.DeleteConfig)
+	mux.HandleFunc(pat.Get("/:type/"), server.ListBlobs)
+	mux.HandleFunc(pat.Get("/:repo/:type/"), server.ListBlobs)
+	mux.HandleFunc(pat.Head("/:type/:name"), server.CheckBlob)
+	mux.HandleFunc(pat.Head("/:repo/:type/:name"), server.CheckBlob)
+	mux.HandleFunc(pat.Get("/:type/:name"), server.GetBlob)
+	mux.HandleFunc(pat.Get("/:repo/:type/:name"), server.GetBlob)
+	mux.HandleFunc(pat.Post("/:type/:name"), server.SaveBlob)
+	mux.HandleFunc(pat.Post("/:repo/:type/:name"), server.SaveBlob)
+	mux.HandleFunc(pat.Delete("/:type/:name"), server.DeleteBlob)
+	mux.HandleFunc(pat.Delete("/:repo/:type/:name"), server.DeleteBlob)
+	mux.HandleFunc(pat.Post("/"), server.CreateRepo)
+	mux.HandleFunc(pat.Post("/:repo"), server.CreateRepo)
+	mux.HandleFunc(pat.Post("/:repo/"), server.CreateRepo)
 
 	return mux
 }

--- a/mux.go
+++ b/mux.go
@@ -12,28 +12,7 @@ import (
 	"goji.io/pat"
 )
 
-// Config struct holds program configuration.
-var Config = struct {
-	Path         string
-	Listen       string
-	Log          string
-	CPUProfile   string
-	TLSKey       string
-	TLSCert      string
-	TLS          bool
-	NoAuth       bool
-	AppendOnly   bool
-	PrivateRepos bool
-	Prometheus   bool
-	Debug        bool
-	Version      bool
-}{
-	Path:       "/tmp/restic",
-	Listen:     ":8000",
-	AppendOnly: false,
-}
-
-func debugHandler(next http.Handler) http.Handler {
+func (c Config) debugHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			log.Printf("%s %s", r.Method, r.URL)
@@ -41,8 +20,8 @@ func debugHandler(next http.Handler) http.Handler {
 		})
 }
 
-func logHandler(next http.Handler) http.Handler {
-	accessLog, err := os.OpenFile(Config.Log, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+func (c Config) logHandler(next http.Handler) http.Handler {
+	accessLog, err := os.OpenFile(c.Log, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
 		log.Fatalf("error: %v", err)
 	}
@@ -50,43 +29,43 @@ func logHandler(next http.Handler) http.Handler {
 	return handlers.CombinedLoggingHandler(accessLog, next)
 }
 
-// NewMux is master HTTP multiplexer/router.
-func NewMux() *goji.Mux {
+// NewHandler returns the master HTTP multiplexer/router.
+func NewHandler(config Config) *goji.Mux {
 	mux := goji.NewMux()
 
-	if Config.Debug {
-		mux.Use(debugHandler)
+	if config.Debug {
+		mux.Use(config.debugHandler)
 	}
 
-	if Config.Log != "" {
-		mux.Use(logHandler)
+	if config.Log != "" {
+		mux.Use(config.logHandler)
 	}
 
-	if Config.Prometheus {
+	if config.Prometheus {
 		mux.Handle(pat.Get("/metrics"), promhttp.Handler())
 	}
 
-	mux.HandleFunc(pat.Head("/config"), CheckConfig)
-	mux.HandleFunc(pat.Head("/:repo/config"), CheckConfig)
-	mux.HandleFunc(pat.Get("/config"), GetConfig)
-	mux.HandleFunc(pat.Get("/:repo/config"), GetConfig)
-	mux.HandleFunc(pat.Post("/config"), SaveConfig)
-	mux.HandleFunc(pat.Post("/:repo/config"), SaveConfig)
-	mux.HandleFunc(pat.Delete("/config"), DeleteConfig)
-	mux.HandleFunc(pat.Delete("/:repo/config"), DeleteConfig)
-	mux.HandleFunc(pat.Get("/:type/"), ListBlobs)
-	mux.HandleFunc(pat.Get("/:repo/:type/"), ListBlobs)
-	mux.HandleFunc(pat.Head("/:type/:name"), CheckBlob)
-	mux.HandleFunc(pat.Head("/:repo/:type/:name"), CheckBlob)
-	mux.HandleFunc(pat.Get("/:type/:name"), GetBlob)
-	mux.HandleFunc(pat.Get("/:repo/:type/:name"), GetBlob)
-	mux.HandleFunc(pat.Post("/:type/:name"), SaveBlob)
-	mux.HandleFunc(pat.Post("/:repo/:type/:name"), SaveBlob)
-	mux.HandleFunc(pat.Delete("/:type/:name"), DeleteBlob)
-	mux.HandleFunc(pat.Delete("/:repo/:type/:name"), DeleteBlob)
-	mux.HandleFunc(pat.Post("/"), CreateRepo)
-	mux.HandleFunc(pat.Post("/:repo"), CreateRepo)
-	mux.HandleFunc(pat.Post("/:repo/"), CreateRepo)
+	mux.HandleFunc(pat.Head("/config"), config.CheckConfig)
+	mux.HandleFunc(pat.Head("/:repo/config"), config.CheckConfig)
+	mux.HandleFunc(pat.Get("/config"), config.GetConfig)
+	mux.HandleFunc(pat.Get("/:repo/config"), config.GetConfig)
+	mux.HandleFunc(pat.Post("/config"), config.SaveConfig)
+	mux.HandleFunc(pat.Post("/:repo/config"), config.SaveConfig)
+	mux.HandleFunc(pat.Delete("/config"), config.DeleteConfig)
+	mux.HandleFunc(pat.Delete("/:repo/config"), config.DeleteConfig)
+	mux.HandleFunc(pat.Get("/:type/"), config.ListBlobs)
+	mux.HandleFunc(pat.Get("/:repo/:type/"), config.ListBlobs)
+	mux.HandleFunc(pat.Head("/:type/:name"), config.CheckBlob)
+	mux.HandleFunc(pat.Head("/:repo/:type/:name"), config.CheckBlob)
+	mux.HandleFunc(pat.Get("/:type/:name"), config.GetBlob)
+	mux.HandleFunc(pat.Get("/:repo/:type/:name"), config.GetBlob)
+	mux.HandleFunc(pat.Post("/:type/:name"), config.SaveBlob)
+	mux.HandleFunc(pat.Post("/:repo/:type/:name"), config.SaveBlob)
+	mux.HandleFunc(pat.Delete("/:type/:name"), config.DeleteBlob)
+	mux.HandleFunc(pat.Delete("/:repo/:type/:name"), config.DeleteBlob)
+	mux.HandleFunc(pat.Post("/"), config.CreateRepo)
+	mux.HandleFunc(pat.Post("/:repo"), config.CreateRepo)
+	mux.HandleFunc(pat.Post("/:repo/"), config.CreateRepo)
 
 	return mux
 }


### PR DESCRIPTION
I know this diff looks huge, but it's actually pretty simple: instead of a global value named `Config`, the identifier named `Config` is now a `struct` type. Instead of having all sorts of global configuration, we confine it to that struct... and attach the handlers as methods on the struct.

It's a lot cleaner, in that CLI options are confined to `main` and the main() function just builds a `Config` struct like any other user of the library would.

This makes it possible to use the `restserver` package as a library.

The default configuration is still preserved.

Closes #66

/cc @rawtaz