### PR TITLE
Add --max-size flag to limit size of repositories

### DIFF
--- a/cmd/rest-server/main.go
+++ b/cmd/rest-server/main.go
@@ -41,7 +41,7 @@ func init() {
 	flags.BoolVar(&server.Debug, "debug", server.Debug, "output debug messages")
 	flags.StringVar(&server.Listen, "listen", server.Listen, "listen address")
 	flags.StringVar(&server.Log, "log", server.Log, "log HTTP requests in the combined log format")
-	flags.Uint64Var(&server.MaxRepoSize, "max-size", server.MaxRepoSize, "the maximum size of the repository in bytes")
+	flags.Int64Var(&server.MaxRepoSize, "max-size", server.MaxRepoSize, "the maximum size of the repository in bytes")
 	flags.StringVar(&server.Path, "path", server.Path, "data directory")
 	flags.BoolVar(&server.TLS, "tls", server.TLS, "turn on TLS support")
 	flags.StringVar(&server.TLSCert, "tls-cert", server.TLSCert, "TLS certificate path")

--- a/cmd/rest-server/main.go
+++ b/cmd/rest-server/main.go
@@ -41,6 +41,7 @@ func init() {
 	flags.BoolVar(&server.Debug, "debug", server.Debug, "output debug messages")
 	flags.StringVar(&server.Listen, "listen", server.Listen, "listen address")
 	flags.StringVar(&server.Log, "log", server.Log, "log HTTP requests in the combined log format")
+	flags.Uint64Var(&server.MaxRepoSize, "max-size", server.MaxRepoSize, "the maximum size of the repository in bytes")
 	flags.StringVar(&server.Path, "path", server.Path, "data directory")
 	flags.BoolVar(&server.TLS, "tls", server.TLS, "turn on TLS support")
 	flags.StringVar(&server.TLSCert, "tls-cert", server.TLSCert, "TLS certificate path")

--- a/handlers.go
+++ b/handlers.go
@@ -555,6 +555,7 @@ func (s Server) SaveBlob(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			atomic.StoreUint64(&s.repoSize, initialSize)
+			currentSize = initialSize
 		}
 
 		if currentSize+uint64(contentLen) > s.MaxRepoSize {

--- a/handlers.go
+++ b/handlers.go
@@ -529,7 +529,6 @@ func (s *Server) SaveBlob(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// ensure this blob does not put us over the size limit (if there is one)
-	// var contentLen, availableSpace int64
 	var outFile io.Writer = tf
 	if s.MaxRepoSize != 0 {
 		var errCode int

--- a/handlers.go
+++ b/handlers.go
@@ -528,7 +528,7 @@ func (s *Server) SaveBlob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// ensure this blob does not put us over the size limit (if there is one)
+	// ensure this blob does not put us over the repo size limit (if there is one)
 	var outFile io.Writer = tf
 	if s.MaxRepoSize != 0 {
 		var errCode int

--- a/handlers.go
+++ b/handlers.go
@@ -41,7 +41,7 @@ type Server struct {
 	repoSize int64 // must be accessed using sync/atomic
 }
 
-func (s Server) isHashed(dir string) bool {
+func (s *Server) isHashed(dir string) bool {
 	return dir == "data"
 }
 
@@ -60,7 +60,7 @@ func valid(name string) bool {
 
 var validTypes = []string{"data", "index", "keys", "locks", "snapshots", "config"}
 
-func (s Server) isValidType(name string) bool {
+func (s *Server) isValidType(name string) bool {
 	for _, tpe := range validTypes {
 		if name == tpe {
 			return true
@@ -91,7 +91,7 @@ func join(base string, names ...string) (string, error) {
 }
 
 // getRepo returns the repository location, relative to s.Path.
-func (s Server) getRepo(r *http.Request) string {
+func (s *Server) getRepo(r *http.Request) string {
 	if strings.HasPrefix(fmt.Sprintf("%s", middleware.Pattern(r.Context())), "/:repo") {
 		return pat.Param(r, "repo")
 	}
@@ -100,7 +100,7 @@ func (s Server) getRepo(r *http.Request) string {
 }
 
 // getPath returns the path for a file type in the repo.
-func (s Server) getPath(r *http.Request, fileType string) (string, error) {
+func (s *Server) getPath(r *http.Request, fileType string) (string, error) {
 	if !s.isValidType(fileType) {
 		return "", errors.New("invalid file type")
 	}
@@ -108,7 +108,7 @@ func (s Server) getPath(r *http.Request, fileType string) (string, error) {
 }
 
 // getFilePath returns the path for a file in the repo.
-func (s Server) getFilePath(r *http.Request, fileType, name string) (string, error) {
+func (s *Server) getFilePath(r *http.Request, fileType, name string) (string, error) {
 	if !s.isValidType(fileType) {
 		return "", errors.New("invalid file type")
 	}
@@ -125,7 +125,7 @@ func (s Server) getFilePath(r *http.Request, fileType, name string) (string, err
 }
 
 // getUser returns the username from the request, or an empty string if none.
-func (s Server) getUser(r *http.Request) string {
+func (s *Server) getUser(r *http.Request) string {
 	username, _, ok := r.BasicAuth()
 	if !ok {
 		return ""
@@ -134,7 +134,7 @@ func (s Server) getUser(r *http.Request) string {
 }
 
 // getMetricLabels returns the prometheus labels from the request.
-func (s Server) getMetricLabels(r *http.Request) prometheus.Labels {
+func (s *Server) getMetricLabels(r *http.Request) prometheus.Labels {
 	labels := prometheus.Labels{
 		"user": s.getUser(r),
 		"repo": s.getRepo(r),
@@ -155,7 +155,7 @@ func isUserPath(username, path string) bool {
 
 // AuthHandler wraps h with a http.HandlerFunc that performs basic authentication against the user/passwords pairs
 // stored in f and returns the http.HandlerFunc.
-func (s Server) AuthHandler(f *HtpasswdFile, h http.Handler) http.HandlerFunc {
+func (s *Server) AuthHandler(f *HtpasswdFile, h http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		username, password, ok := r.BasicAuth()
 		if !ok || !f.Validate(username, password) {
@@ -171,7 +171,7 @@ func (s Server) AuthHandler(f *HtpasswdFile, h http.Handler) http.HandlerFunc {
 }
 
 // CheckConfig checks whether a configuration exists.
-func (s Server) CheckConfig(w http.ResponseWriter, r *http.Request) {
+func (s *Server) CheckConfig(w http.ResponseWriter, r *http.Request) {
 	if s.Debug {
 		log.Println("CheckConfig()")
 	}
@@ -194,7 +194,7 @@ func (s Server) CheckConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 // GetConfig allows for a config to be retrieved.
-func (s Server) GetConfig(w http.ResponseWriter, r *http.Request) {
+func (s *Server) GetConfig(w http.ResponseWriter, r *http.Request) {
 	if s.Debug {
 		log.Println("GetConfig()")
 	}
@@ -217,7 +217,7 @@ func (s Server) GetConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 // SaveConfig allows for a config to be saved.
-func (s Server) SaveConfig(w http.ResponseWriter, r *http.Request) {
+func (s *Server) SaveConfig(w http.ResponseWriter, r *http.Request) {
 	if s.Debug {
 		log.Println("SaveConfig()")
 	}
@@ -255,7 +255,7 @@ func (s Server) SaveConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 // DeleteConfig removes a config.
-func (s Server) DeleteConfig(w http.ResponseWriter, r *http.Request) {
+func (s *Server) DeleteConfig(w http.ResponseWriter, r *http.Request) {
 	if s.Debug {
 		log.Println("DeleteConfig()")
 	}
@@ -290,7 +290,7 @@ const (
 )
 
 // ListBlobs lists all blobs of a given type in an arbitrary order.
-func (s Server) ListBlobs(w http.ResponseWriter, r *http.Request) {
+func (s *Server) ListBlobs(w http.ResponseWriter, r *http.Request) {
 	if s.Debug {
 		log.Println("ListBlobs()")
 	}
@@ -304,7 +304,7 @@ func (s Server) ListBlobs(w http.ResponseWriter, r *http.Request) {
 }
 
 // ListBlobsV1 lists all blobs of a given type in an arbitrary order.
-func (s Server) ListBlobsV1(w http.ResponseWriter, r *http.Request) {
+func (s *Server) ListBlobsV1(w http.ResponseWriter, r *http.Request) {
 	if s.Debug {
 		log.Println("ListBlobsV1()")
 	}
@@ -365,7 +365,7 @@ type Blob struct {
 }
 
 // ListBlobsV2 lists all blobs of a given type, together with their sizes, in an arbitrary order.
-func (s Server) ListBlobsV2(w http.ResponseWriter, r *http.Request) {
+func (s *Server) ListBlobsV2(w http.ResponseWriter, r *http.Request) {
 	if s.Debug {
 		log.Println("ListBlobsV2()")
 	}
@@ -420,7 +420,7 @@ func (s Server) ListBlobsV2(w http.ResponseWriter, r *http.Request) {
 }
 
 // CheckBlob tests whether a blob exists.
-func (s Server) CheckBlob(w http.ResponseWriter, r *http.Request) {
+func (s *Server) CheckBlob(w http.ResponseWriter, r *http.Request) {
 	if s.Debug {
 		log.Println("CheckBlob()")
 	}
@@ -444,7 +444,7 @@ func (s Server) CheckBlob(w http.ResponseWriter, r *http.Request) {
 }
 
 // GetBlob retrieves a blob from the repository.
-func (s Server) GetBlob(w http.ResponseWriter, r *http.Request) {
+func (s *Server) GetBlob(w http.ResponseWriter, r *http.Request) {
 	if s.Debug {
 		log.Println("GetBlob()")
 	}
@@ -495,7 +495,7 @@ func tallySize(path string) (int64, error) {
 }
 
 // SaveBlob saves a blob to the repository.
-func (s Server) SaveBlob(w http.ResponseWriter, r *http.Request) {
+func (s *Server) SaveBlob(w http.ResponseWriter, r *http.Request) {
 	if s.Debug {
 		log.Println("SaveBlob()")
 	}
@@ -517,12 +517,10 @@ func (s Server) SaveBlob(w http.ResponseWriter, r *http.Request) {
 			tf, err = os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0600)
 		}
 	}
-
 	if os.IsExist(err) {
 		http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
 		return
 	}
-
 	if err != nil {
 		if s.Debug {
 			log.Print(err)
@@ -532,49 +530,23 @@ func (s Server) SaveBlob(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// ensure this blob does not put us over the size limit (if there is one)
-	var contentLen, availableSpace int64
-	var body io.Reader = r.Body
+	// var contentLen, availableSpace int64
+	var outFile io.Writer = tf
 	if s.MaxRepoSize != 0 {
-		var err error
-		contentLen, err = strconv.ParseInt(r.Header.Get("Content-Length"), 10, 64)
+		var errCode int
+		outFile, errCode, err = s.maxSizeWriter(r, tf)
 		if err != nil {
 			if s.Debug {
 				log.Println(err)
 			}
-			http.Error(w, http.StatusText(http.StatusLengthRequired), http.StatusLengthRequired)
+			if errCode > 0 {
+				http.Error(w, http.StatusText(errCode), errCode)
+			}
 			return
 		}
-
-		currentSize := atomic.LoadInt64(&s.repoSize)
-		if currentSize == 0 {
-			initialSize, err := tallySize(s.Path)
-			if err != nil {
-				if s.Debug {
-					log.Println(err)
-				}
-				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-				return
-			}
-			atomic.StoreInt64(&s.repoSize, initialSize)
-			currentSize = initialSize
-		}
-
-		// if content-length is trustworthy, we can save time and issue a polite error
-		if currentSize+contentLen > s.MaxRepoSize {
-			if s.Debug {
-				log.Printf("incoming blob (%d bytes) would go over maximum size of repository (%d bytes)",
-					contentLen, s.MaxRepoSize)
-			}
-			http.Error(w, http.StatusText(http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge)
-			return
-		}
-
-		// we can't always trust content-length
-		availableSpace = s.MaxRepoSize - currentSize
-		body = io.LimitReader(r.Body, availableSpace)
 	}
 
-	written, err := io.Copy(tf, body)
+	written, err := io.Copy(outFile, r.Body)
 	if err != nil {
 		_ = tf.Close()
 		_ = os.Remove(path)
@@ -605,18 +577,18 @@ func (s Server) SaveBlob(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// now that write has succeeded, update repo size
-	if s.MaxRepoSize != 0 {
-		atomic.AddInt64(&s.repoSize, written)
+	// if s.MaxRepoSize != 0 {
+	// 	atomic.AddInt64(&s.repoSize, written)
 
-		// check if space quota reached or exceeded
-		if written >= availableSpace {
-			if s.Debug {
-				log.Printf("wrote %d/%d bytes (space limit reached: %d bytes)", written, contentLen, s.MaxRepoSize)
-			}
-			http.Error(w, http.StatusText(http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge)
-			return
-		}
-	}
+	// 	// check if space quota reached or exceeded
+	// 	if written >= availableSpace {
+	// 		if s.Debug {
+	// 			log.Printf("wrote %d/%d bytes (space limit reached: %d bytes)", written, contentLen, s.MaxRepoSize)
+	// 		}
+	// 		http.Error(w, http.StatusText(http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge)
+	// 		return
+	// 	}
+	// }
 
 	if s.Prometheus {
 		labels := s.getMetricLabels(r)
@@ -626,7 +598,7 @@ func (s Server) SaveBlob(w http.ResponseWriter, r *http.Request) {
 }
 
 // DeleteBlob deletes a blob from the repository.
-func (s Server) DeleteBlob(w http.ResponseWriter, r *http.Request) {
+func (s *Server) DeleteBlob(w http.ResponseWriter, r *http.Request) {
 	if s.Debug {
 		log.Println("DeleteBlob()")
 	}
@@ -670,7 +642,7 @@ func (s Server) DeleteBlob(w http.ResponseWriter, r *http.Request) {
 }
 
 // CreateRepo creates repository directories.
-func (s Server) CreateRepo(w http.ResponseWriter, r *http.Request) {
+func (s *Server) CreateRepo(w http.ResponseWriter, r *http.Request) {
 	if s.Debug {
 		log.Println("CreateRepo()")
 	}
@@ -713,4 +685,39 @@ func (s Server) CreateRepo(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+}
+
+// maxSizeWriter wraps w in a writer that enforces s.MaxRepoSize.
+// If there is an error, a status code and the error are returned.
+func (s *Server) maxSizeWriter(req *http.Request, w io.Writer) (io.Writer, int, error) {
+	// if we haven't yet computed the size of the repo, do so now
+	currentSize := atomic.LoadInt64(&s.repoSize)
+	if currentSize == 0 {
+		initialSize, err := tallySize(s.Path)
+		if err != nil {
+			return nil, http.StatusInternalServerError, err
+		}
+		atomic.StoreInt64(&s.repoSize, initialSize)
+		currentSize = initialSize
+	}
+
+	// if content-length is set and is trustworthy, we can save some time
+	// and issue a polite error if it declares a size that's too big; since
+	// we expect the vast majority of clients will be honest, so this check
+	// can only help save time
+	if contentLenStr := req.Header.Get("Content-Length"); contentLenStr != "" {
+		contentLen, err := strconv.ParseInt(contentLenStr, 10, 64)
+		if err != nil {
+			return nil, http.StatusLengthRequired, err
+		}
+		if currentSize+contentLen > s.MaxRepoSize {
+			err := fmt.Errorf("incoming blob (%d bytes) would exceed maximum size of repository (%d bytes)",
+				contentLen, s.MaxRepoSize)
+			return nil, http.StatusRequestEntityTooLarge, err
+		}
+	}
+
+	// since we can't always trust content-length, we will wrap the writer
+	// in a custom writer that enforces the size limit during writes
+	return maxSizeWriter{Writer: w, server: s}, 0, nil
 }

--- a/handlers.go
+++ b/handlers.go
@@ -610,7 +610,7 @@ func (s *Server) DeleteBlob(w http.ResponseWriter, r *http.Request) {
 	var size int64
 	if s.Prometheus || s.MaxRepoSize > 0 {
 		stat, err := os.Stat(path)
-		if err != nil {
+		if err == nil {
 			size = stat.Size()
 		}
 	}

--- a/handlers.go
+++ b/handlers.go
@@ -576,20 +576,6 @@ func (s *Server) SaveBlob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// now that write has succeeded, update repo size
-	// if s.MaxRepoSize != 0 {
-	// 	atomic.AddInt64(&s.repoSize, written)
-
-	// 	// check if space quota reached or exceeded
-	// 	if written >= availableSpace {
-	// 		if s.Debug {
-	// 			log.Printf("wrote %d/%d bytes (space limit reached: %d bytes)", written, contentLen, s.MaxRepoSize)
-	// 		}
-	// 		http.Error(w, http.StatusText(http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge)
-	// 		return
-	// 	}
-	// }
-
 	if s.Prometheus {
 		labels := s.getMetricLabels(r)
 		metricBlobWriteTotal.With(labels).Inc()

--- a/handlers.go
+++ b/handlers.go
@@ -565,7 +565,7 @@ func (s Server) SaveBlob(w http.ResponseWriter, r *http.Request) {
 				log.Printf("incoming blob (%d bytes) would go over maximum size of repository (%d bytes)",
 					contentLen, s.MaxRepoSize)
 			}
-			http.Error(w, http.StatusText(http.StatusInsufficientStorage), http.StatusInsufficientStorage)
+			http.Error(w, http.StatusText(http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge)
 			return
 		}
 
@@ -613,7 +613,7 @@ func (s Server) SaveBlob(w http.ResponseWriter, r *http.Request) {
 			if s.Debug {
 				log.Printf("wrote %d/%d bytes (space limit reached: %d bytes)", written, contentLen, s.MaxRepoSize)
 			}
-			http.Error(w, http.StatusText(http.StatusInsufficientStorage), http.StatusInsufficientStorage)
+			http.Error(w, http.StatusText(http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge)
 			return
 		}
 	}

--- a/maxsizewriter.go
+++ b/maxsizewriter.go
@@ -3,6 +3,8 @@ package restserver
 import (
 	"fmt"
 	"io"
+	"net/http"
+	"strconv"
 	"sync/atomic"
 )
 
@@ -16,20 +18,63 @@ type maxSizeWriter struct {
 }
 
 func (w maxSizeWriter) Write(p []byte) (n int, err error) {
-	if int64(len(p)) > w.spaceRemaining() {
+	if int64(len(p)) > w.server.repoSpaceRemaining() {
 		return 0, fmt.Errorf("repository has reached maximum size (%d bytes)", w.server.MaxRepoSize)
 	}
 	n, err = w.Writer.Write(p)
-	w.incrementUsage(int64(n))
+	w.server.incrementRepoSpaceUsage(int64(n))
 	return n, err
 }
 
-func (w maxSizeWriter) incrementUsage(by int64) {
-	atomic.AddInt64(&w.server.repoSize, by)
+// maxSizeWriter wraps w in a writer that enforces s.MaxRepoSize.
+// If there is an error, a status code and the error are returned.
+func (s *Server) maxSizeWriter(req *http.Request, w io.Writer) (io.Writer, int, error) {
+	// if we haven't yet computed the size of the repo, do so now
+	currentSize := atomic.LoadInt64(&s.repoSize)
+	if currentSize == 0 {
+		initialSize, err := tallySize(s.Path)
+		if err != nil {
+			return nil, http.StatusInternalServerError, err
+		}
+		atomic.StoreInt64(&s.repoSize, initialSize)
+		currentSize = initialSize
+	}
+
+	// if content-length is set and is trustworthy, we can save some time
+	// and issue a polite error if it declares a size that's too big; since
+	// we expect the vast majority of clients will be honest, so this check
+	// can only help save time
+	if contentLenStr := req.Header.Get("Content-Length"); contentLenStr != "" {
+		contentLen, err := strconv.ParseInt(contentLenStr, 10, 64)
+		if err != nil {
+			return nil, http.StatusLengthRequired, err
+		}
+		if currentSize+contentLen > s.MaxRepoSize {
+			err := fmt.Errorf("incoming blob (%d bytes) would exceed maximum size of repository (%d bytes)",
+				contentLen, s.MaxRepoSize)
+			return nil, http.StatusRequestEntityTooLarge, err
+		}
+	}
+
+	// since we can't always trust content-length, we will wrap the writer
+	// in a custom writer that enforces the size limit during writes
+	return maxSizeWriter{Writer: w, server: s}, 0, nil
 }
 
-func (w maxSizeWriter) spaceRemaining() int64 {
-	maxSize := w.server.MaxRepoSize
-	currentSize := atomic.LoadInt64(&w.server.repoSize)
+// repoSpaceRemaining returns how much space is available in the repo
+// according to s.MaxRepoSize. s.repoSize must already be set.
+// If there is no limit, -1 is returned.
+func (s *Server) repoSpaceRemaining() int64 {
+	if s.MaxRepoSize == 0 {
+		return -1
+	}
+	maxSize := s.MaxRepoSize
+	currentSize := atomic.LoadInt64(&s.repoSize)
 	return maxSize - currentSize
+}
+
+// incrementRepoSpaceUsage increments the current repo size (which
+// must already be initialized).
+func (s *Server) incrementRepoSpaceUsage(by int64) {
+	atomic.AddInt64(&s.repoSize, by)
 }

--- a/maxsizewriter.go
+++ b/maxsizewriter.go
@@ -1,0 +1,35 @@
+package restserver
+
+import (
+	"fmt"
+	"io"
+	"sync/atomic"
+)
+
+// maxSizeWriter limits the number of bytes written
+// to the space that is currently available as given by
+// the server's MaxRepoSize. This type is safe for use
+// by multiple goroutines sharing the same *Server.
+type maxSizeWriter struct {
+	io.Writer
+	server *Server
+}
+
+func (w maxSizeWriter) Write(p []byte) (n int, err error) {
+	if int64(len(p)) > w.spaceRemaining() {
+		return 0, fmt.Errorf("repository has reached maximum size (%d bytes)", w.server.MaxRepoSize)
+	}
+	n, err = w.Writer.Write(p)
+	w.incrementUsage(int64(n))
+	return n, err
+}
+
+func (w maxSizeWriter) incrementUsage(by int64) {
+	atomic.AddInt64(&w.server.repoSize, by)
+}
+
+func (w maxSizeWriter) spaceRemaining() int64 {
+	maxSize := w.server.MaxRepoSize
+	currentSize := atomic.LoadInt64(&w.server.repoSize)
+	return maxSize - currentSize
+}

--- a/mux.go
+++ b/mux.go
@@ -12,7 +12,7 @@ import (
 	"goji.io/pat"
 )
 
-func (s Server) debugHandler(next http.Handler) http.Handler {
+func (s *Server) debugHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			log.Printf("%s %s", r.Method, r.URL)
@@ -20,7 +20,7 @@ func (s Server) debugHandler(next http.Handler) http.Handler {
 		})
 }
 
-func (s Server) logHandler(next http.Handler) http.Handler {
+func (s *Server) logHandler(next http.Handler) http.Handler {
 	accessLog, err := os.OpenFile(s.Log, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
 		log.Fatalf("error: %v", err)


### PR DESCRIPTION
The --max-size limits the number of bytes that can be stored to a repo. It only takes effect on SaveBlob.

Closes https://github.com/restic/rest-server/issues/65

Can see previous discussion at https://github.com/mholt/rest-server/pull/1

/cc @dotlambda