### PR TITLE
Implement TLS client authentication

### DIFF
--- a/cmd/rest-server/main.go
+++ b/cmd/rest-server/main.go
@@ -50,7 +50,7 @@ func init() {
 	flags.StringVar(&server.TLSCert, "tls-cert", server.TLSCert, "TLS certificate path")
 	flags.StringVar(&server.TLSKey, "tls-key", server.TLSKey, "TLS key path")
 	flags.StringVar(&server.TLSClientCerts, "tls-client-certs", server.TLSClientCerts, "PEM encoded client certificates for TLS authentication")
-	flags.BoolVar(&server.NoAuth, "no-auth", server.NoAuth, "disable .htpasswd authentication")
+	flags.BoolVar(&server.NoHTTPAuth, "no-http-auth", server.NoHTTPAuth, "disable .htpasswd authentication")
 	flags.BoolVar(&server.AppendOnly, "append-only", server.AppendOnly, "enable append only mode")
 	flags.BoolVar(&server.PrivateRepos, "private-repos", server.PrivateRepos, "users can only access their private repo")
 	flags.BoolVar(&server.Prometheus, "prometheus", server.Prometheus, "enable Prometheus metrics")
@@ -102,7 +102,7 @@ func listenAndServeTLS(addr, certFile, keyFile, clientCertsFile string, handler 
 		}
 
 		authType := tls.VerifyClientCertIfGiven
-		if server.NoAuth {
+		if server.NoHTTPAuth {
 			authType = tls.RequireAndVerifyClientCert
 		}
 		httpServer.TLSConfig = &tls.Config{
@@ -116,7 +116,7 @@ func listenAndServeTLS(addr, certFile, keyFile, clientCertsFile string, handler 
 
 func getHandler(server restserver.Server) (http.Handler, error) {
 	mux := restserver.NewHandler(server)
-	if server.NoAuth {
+	if server.NoHTTPAuth {
 		log.Println("Authentication disabled")
 		return mux, nil
 	}

--- a/cmd/rest-server/main_test.go
+++ b/cmd/rest-server/main_test.go
@@ -88,7 +88,7 @@ func TestGetHandler(t *testing.T) {
 	}
 
 	// With NoAuth = true and no .htpasswd
-	_, err = getHandler(restserver.Server{NoAuth: true, Path: dir})
+	_, err = getHandler(restserver.Server{NoHTTPAuth: true, Path: dir})
 	if err != nil {
 		t.Errorf("NoAuth=true: expected no error, got %v", err)
 	}

--- a/cmd/rest-server/main_test.go
+++ b/cmd/rest-server/main_test.go
@@ -46,7 +46,7 @@ func TestTLSSettings(t *testing.T) {
 			server.TLSKey = test.passed.TLSKey
 			server.TLSCert = test.passed.TLSCert
 
-			gotTLS, gotKey, gotCert, err := tlsSettings()
+			gotTLS, gotKey, gotCert, _, err := tlsSettings()
 			if err != nil && !test.expected.Error {
 				t.Fatalf("tls_settings returned err (%v)", err)
 			}

--- a/handlers.go
+++ b/handlers.go
@@ -30,7 +30,7 @@ type Server struct {
 	TLSCert        string
 	TLSClientCerts string
 	TLS            bool
-	NoAuth         bool
+	NoHTTPAuth     bool
 	AppendOnly     bool
 	PrivateRepos   bool
 	Prometheus     bool

--- a/handlers.go
+++ b/handlers.go
@@ -22,19 +22,20 @@ import (
 
 // Server determines how a Mux's handlers behave.
 type Server struct {
-	Path         string
-	Listen       string
-	Log          string
-	CPUProfile   string
-	TLSKey       string
-	TLSCert      string
-	TLS          bool
-	NoAuth       bool
-	AppendOnly   bool
-	PrivateRepos bool
-	Prometheus   bool
-	Debug        bool
-	MaxRepoSize  int64
+	Path           string
+	Listen         string
+	Log            string
+	CPUProfile     string
+	TLSKey         string
+	TLSCert        string
+	TLSClientCerts string
+	TLS            bool
+	NoAuth         bool
+	AppendOnly     bool
+	PrivateRepos   bool
+	Prometheus     bool
+	Debug          bool
+	MaxRepoSize    int64
 
 	repoSize int64 // must be accessed using sync/atomic
 }


### PR DESCRIPTION
This pull request implements TLS client certificate authentication as requested in #73.

I tested this briefly with `openssl s_client` and `restic` which already has support for TLS client certificates due to https://github.com/restic/restic/commit/e805b968b16b60a70c82b6218d793e22c4b86208. The code seems to work but further tests would be welcome.

Regarding the authentication itself: TLS client authentication is required if `--no-http-auth` and `--tls-client-certs` have been passed. If `--tls-client-certs` was passed but `--no-http-auth` wasn't it's entirely optional. This behavior is also documented in the `README.md`.

Any thoughts on this? I just quickly hacked this together, did I miss anything?