### PR TITLE
missing htpasswd-flag "-b" when using password from cli

### DIFF
--- a/docker/create_user
+++ b/docker/create_user
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+HTPASSWD="htpasswd"
+
 if [ -z "$1" ]; then
     echo "create_user [username]"
     echo "or"
@@ -7,4 +9,10 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-htpasswd -s $PASSWORD_FILE $1 $2
+if [ ! -z "$2" ]; then
+    HTPASSWD="$HTPASSWD -b"
+fi
+
+HTPASSWD="$HTPASSWD -s $PASSWORD_FILE $1 $2"
+
+$HTPASSWD


### PR DESCRIPTION
Hi,

i got an error when i try to add an user in that way:
```
docker exec -it rest_server create_user myuser mypassword
```

The error is:
```
Usage:
	htpasswd [-cimBdpsDv] [-C cost] passwordfile username
	htpasswd -b[cmBdpsDv] [-C cost] passwordfile username password

	htpasswd -n[imBdps] [-C cost] username
	htpasswd -nb[mBdps] [-C cost] username password
 -c  Create a new file.
 -n  Don't update file; display results on stdout.
 -b  Use the password from the command line rather than prompting for it.
 -i  Read password from stdin without verification (for script usage).
 -m  Force MD5 encryption of the password (default).
 -B  Force bcrypt encryption of the password (very secure).
 -C  Set the computing time used for the bcrypt algorithm
     (higher is more secure but slower, default: 5, valid: 4 to 31).
 -d  Force CRYPT encryption of the password (8 chars max, insecure).
 -s  Force SHA encryption of the password (insecure).
 -p  Do not encrypt the password (plaintext, insecure).
 -D  Delete the specified user.
 -v  Verify password for the specified user.
On other systems than Windows and NetWare the '-p' flag will probably not work.
```

I think the flag "-b" is missing when using password from cli. I fixed the problem with:
```
--- create_user.orig	2018-08-21 13:13:00.553901028 +0200
+++ create_user	2018-08-21 13:02:52.659960124 +0200
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+HTPASSWD="htpasswd"
+
 if [ -z "$1" ]; then
     echo "create_user [username]"
     echo "or"
@@ -7,4 +9,10 @@
     exit 1
 fi
 
-htpasswd -s $PASSWORD_FILE $1 $2
+if [ ! -z "$2" ]; then
+    HTPASSWD="$HTPASSWD -b"
+fi
+
+HTPASSWD="$HTPASSWD -s $PASSWORD_FILE $1 $2"
+
+$HTPASSWD
```

Regards
Tino