### PR TITLE
Tweak systemd unit file

### DIFF
--- a/examples/systemd/rest-server.service
+++ b/examples/systemd/rest-server.service
@@ -10,7 +10,6 @@ Group=www-data
 ExecStart=/usr/local/bin/rest-server --path /tmp/restic
 Restart=always
 RestartSec=5
-StartLimitInterval=0
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The directive "StartLimitInterval" has been replaced by [StartLimitIntervalSec=interval, StartLimitBurst=burst](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#StartLimitIntervalSec=interval). I'd suggest that the default backoff settings are fine (in Ubuntu 19.10 no more than 5 restarts per 10 seconds, else delayed by 10 seconds per attempt) so this directive can simply be removed.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No, tiny change so assumed not necessary.

Checklist
---------

- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [x] I'm done, this Pull Request is ready for review
