### PR TITLE
Add support for multiple repositories in a folder

### DIFF
--- a/changelog/unreleased/issue-107
+++ b/changelog/unreleased/issue-107
@@ -1,0 +1,5 @@
+Enhancement: Add support for multiple repositories in a folder
+
+
+https://github.com/restic/rest-server/issues/107
+https://github.com/restic/rest-server/pull/108

--- a/handlers.go
+++ b/handlers.go
@@ -90,11 +90,13 @@ func join(base string, names ...string) (string, error) {
 
 // getRepo returns the repository location, relative to s.Path.
 func (s *Server) getRepo(r *http.Request) string {
+	repo := "."
 	if strings.HasPrefix(fmt.Sprintf("%s", middleware.Pattern(r.Context())), "/:repo") {
-		return pat.Param(r, "repo")
+		repo = pat.Param(r, "repo")
+	} else if strings.HasPrefix(fmt.Sprintf("%s", middleware.Pattern(r.Context())), "/:folder/:repo") {
+		repo, _ = join(pat.Param(r, "folder"), pat.Param(r, "repo"))
 	}
-
-	return "."
+	return repo
 }
 
 // getPath returns the path for a file type in the repo.

--- a/mux.go
+++ b/mux.go
@@ -47,25 +47,47 @@ func NewHandler(server Server) *goji.Mux {
 
 	mux.HandleFunc(pat.Head("/config"), server.CheckConfig)
 	mux.HandleFunc(pat.Head("/:repo/config"), server.CheckConfig)
+	mux.HandleFunc(pat.Head("/*/:repo/config"), server.CheckConfig)
+
 	mux.HandleFunc(pat.Get("/config"), server.GetConfig)
 	mux.HandleFunc(pat.Get("/:repo/config"), server.GetConfig)
+	mux.HandleFunc(pat.Get("/:folder/:repo/config"), server.GetConfig)
+
 	mux.HandleFunc(pat.Post("/config"), server.SaveConfig)
 	mux.HandleFunc(pat.Post("/:repo/config"), server.SaveConfig)
+	mux.HandleFunc(pat.Post("/:folder/:repo/config"), server.SaveConfig)
+
 	mux.HandleFunc(pat.Delete("/config"), server.DeleteConfig)
 	mux.HandleFunc(pat.Delete("/:repo/config"), server.DeleteConfig)
+	mux.HandleFunc(pat.Delete("/:folder/:repo/config"), server.DeleteConfig)
+
 	mux.HandleFunc(pat.Get("/:type/"), server.ListBlobs)
 	mux.HandleFunc(pat.Get("/:repo/:type/"), server.ListBlobs)
+	mux.HandleFunc(pat.Get("/:folder/:repo/:type/"), server.ListBlobs)
+
 	mux.HandleFunc(pat.Head("/:type/:name"), server.CheckBlob)
 	mux.HandleFunc(pat.Head("/:repo/:type/:name"), server.CheckBlob)
+	mux.HandleFunc(pat.Head("/:folder/:type/:name"), server.CheckBlob)
+	mux.HandleFunc(pat.Head("/:folder/:repo/:type/:name"), server.CheckBlob)
+
 	mux.HandleFunc(pat.Get("/:type/:name"), server.GetBlob)
 	mux.HandleFunc(pat.Get("/:repo/:type/:name"), server.GetBlob)
+	mux.HandleFunc(pat.Get("/:folder/:type/:name"), server.GetBlob)
+	mux.HandleFunc(pat.Get("/:folder/:repo/:type/:name"), server.GetBlob)
+
 	mux.HandleFunc(pat.Post("/:type/:name"), server.SaveBlob)
 	mux.HandleFunc(pat.Post("/:repo/:type/:name"), server.SaveBlob)
+	mux.HandleFunc(pat.Post("/:folder/:repo/:type/:name"), server.SaveBlob)
+
 	mux.HandleFunc(pat.Delete("/:type/:name"), server.DeleteBlob)
 	mux.HandleFunc(pat.Delete("/:repo/:type/:name"), server.DeleteBlob)
+	mux.HandleFunc(pat.Delete("/:folder/:type/:name"), server.DeleteBlob)
+	mux.HandleFunc(pat.Delete("/:folder/:repo/:type/:name"), server.DeleteBlob)
+
 	mux.HandleFunc(pat.Post("/"), server.CreateRepo)
-	mux.HandleFunc(pat.Post("/:repo"), server.CreateRepo)
 	mux.HandleFunc(pat.Post("/:repo/"), server.CreateRepo)
+
+	mux.HandleFunc(pat.Post("/:folder/:repo/"), server.CreateRepo)
 
 	return mux
 }


### PR DESCRIPTION

What is the purpose of this change? What does it change?
--------------------------------------------------------
This add suport for subdirectories because at the moment only is supported ```/repo```, now we can do ```/group/user``` for example.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #107 


Checklist
---------

- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [ ] I'm done, this Pull Request is ready for review
