### PR TITLE
Make example systemd service more restrictive

### DIFF
--- a/examples/systemd/rest-server.service
+++ b/examples/systemd/rest-server.service
@@ -7,9 +7,16 @@ After=network.target
 Type=simple
 User=www-data
 Group=www-data
-ExecStart=/usr/local/bin/rest-server --path /tmp/restic
+ExecStart=/usr/local/bin/rest-server --path /path/to/backups
 Restart=always
 RestartSec=5
+
+# Optional security enhancements
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=yes
+ReadWritePaths=/path/to/backups
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION

What is the purpose of this change? What does it change?
--------------------------------------------------------

In addition to any existing filesystem restrictions on the (www-data)
backup user these config options uses namespaces and other kernel
features to further restrict what the _rest-server_ is allowed to do.

* `ProtectSystem=strict` and `ReadWritePaths=/path/to/backups` ensures
  that the _rest-server_ is only allowed to write to its data directory.

* `ProtectHome=yes` and `PrivateTmp=yes` limits what the _rest-server_
  gets (read) access to.

* `NoNewPrivileges=yes` prevents the _rest-server_ from using setuid
  binaries, etc to escalate its privileges.

See https://www.freedesktop.org/software/systemd/man/systemd.exec.html
for further details

While at I also replaced the _/tmp/restic_ path with a more explicit
placeholder path. Given that one rarely wants to backup to _/tmp_ I
figured it better to force a choice of path rather than to have
someone accidentally end up using _/tmp/restic_ for their backups.


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No


Checklist
---------

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [x] I'm done, this Pull Request is ready for review
