### PR TITLE
Add flag for inetd-style operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ To learn how to use restic backup client with REST backend, please consult [rest
           --path string          data directory (default "/tmp/restic")
           --private-repos        users can only access their private repo
           --prometheus           enable Prometheus metrics
+          --stdin                accept connections on the socket from stdin
           --tls                  turn on TLS support
           --tls-cert string      TLS certificate path
           --tls-key string       TLS key path

--- a/changelog/unreleased/issue-126
+++ b/changelog/unreleased/issue-126
@@ -1,0 +1,8 @@
+Enhancement: support inetd-style operation
+
+rest-server can be used as a "wait" service under inetd-style supervisors.
+In this case, the "--listen" argument is ignored and the socket is provided
+by the supervisor as stdin. This allows running the server as unprivileged
+process, but still use a low port like 443.
+
+https://github.com/restic/restic-server/issues/126


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Allow using a pre-created socket passed in via stdin. This is how wait-services in inetd have worked for ages and is still supported by modern replacements. 


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #126.


Checklist
---------

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [ ] I'm done, this Pull Request is ready for review
