### PR TITLE
Verify uploaded files

### DIFF
--- a/changelog/unreleased/issue-122
+++ b/changelog/unreleased/issue-122
@@ -1,0 +1,8 @@
+Enhancement: Verify uploaded files
+
+rest-server now verifies that the hash of content of uploaded files matches
+their filename. This ensures that transmission errors are detected and forces
+restic to retry the upload.
+
+https://github.com/restic/rest-server/issues/122
+https://github.com/restic/rest-server/pull/130

--- a/changelog/unreleased/issue-122
+++ b/changelog/unreleased/issue-122
@@ -1,8 +1,9 @@
 Enhancement: Verify uploaded files
 
-rest-server now verifies that the hash of content of uploaded files matches
-their filename. This ensures that transmission errors are detected and forces
-restic to retry the upload.
+The rest-server now by default verifies that the hash of content of uploaded
+files matches their filename. This ensures that transmission errors are
+detected and forces restic to retry the upload. On low-power devices it can
+make sense to disable this check by passing the `--no-verify-upload` flag.
 
 https://github.com/restic/rest-server/issues/122
 https://github.com/restic/rest-server/pull/130

--- a/cmd/rest-server/main.go
+++ b/cmd/rest-server/main.go
@@ -45,6 +45,8 @@ func init() {
 	flags.StringVar(&server.TLSCert, "tls-cert", server.TLSCert, "TLS certificate path")
 	flags.StringVar(&server.TLSKey, "tls-key", server.TLSKey, "TLS key path")
 	flags.BoolVar(&server.NoAuth, "no-auth", server.NoAuth, "disable .htpasswd authentication")
+	flags.BoolVar(&server.NoVerifyUpload, "no-verify-upload", server.NoVerifyUpload,
+		"do not verify the integrity of uploaded data. DO NOT enable unless the rest-server runs on a very low-power device")
 	flags.BoolVar(&server.AppendOnly, "append-only", server.AppendOnly, "enable append only mode")
 	flags.BoolVar(&server.PrivateRepos, "private-repos", server.PrivateRepos, "users can only access their private repo")
 	flags.BoolVar(&server.Prometheus, "prometheus", server.Prometheus, "enable Prometheus metrics")

--- a/handlers.go
+++ b/handlers.go
@@ -29,6 +29,7 @@ type Server struct {
 	Debug            bool
 	MaxRepoSize      int64
 	PanicOnError     bool
+	NoVerifyUpload   bool
 
 	htpasswdFile *HtpasswdFile
 	quotaManager *quota.Manager
@@ -84,10 +85,11 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Pass the request to the repo.Handler
 	opt := repo.Options{
-		AppendOnly:   s.AppendOnly,
-		Debug:        s.Debug,
-		QuotaManager: s.quotaManager, // may be nil
-		PanicOnError: s.PanicOnError,
+		AppendOnly:     s.AppendOnly,
+		Debug:          s.Debug,
+		QuotaManager:   s.quotaManager, // may be nil
+		PanicOnError:   s.PanicOnError,
+		NoVerifyUpload: s.NoVerifyUpload,
 	}
 	if s.Prometheus {
 		opt.BlobMetricFunc = makeBlobMetricFunc(username, folderPath)


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
The restic uses the sha256 hash to calculate filenames based on the file content. Check on the rest-server side that the uploaded file is intact and reject it otherwise.

This PR complements https://github.com/restic/restic/pull/3178 . However, this PR does not depend on the mentioned restic PR and should work with every restic version.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes #122

Checklist
---------

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [x] I'm done, this Pull Request is ready for review
