### PR TITLE
Security: Prevent loading of usernames containing a slash

### DIFF
--- a/changelog/unreleased/issue-131
+++ b/changelog/unreleased/issue-131
@@ -1,0 +1,16 @@
+Security: Prevent loading of usernames containing a slash
+
+"/" is valid char in HTTP authorization headers, but is also used in
+rest-server to map usernames to private repos.
+
+This commit prevents loading maliciously composed usernames like
+"/foo/config" by restricting the allowed characters to the unicode
+character class, numbers, "-", "." and "@".
+
+This prevents requests to other users files like:
+
+curl -v  -X DELETE -u foo/config:attack  http://localhost:8000/foo/config
+
+https://github.com/restic/rest-server/issues/131
+https://github.com/restic/rest-server/pull/132
+

--- a/htpasswd.go
+++ b/htpasswd.go
@@ -100,6 +100,8 @@ func (h *HtpasswdFile) throttleTimer() {
 	}
 }
 
+var validUsernameRegexp = regexp.MustCompile(`^[\p{L}@.-]+$`)
+
 // Reload reloads the htpasswd file. If the reload fails, the Users map is not changed and the error is returned.
 func (h *HtpasswdFile) Reload() error {
 	r, err := os.Open(h.path)
@@ -119,6 +121,10 @@ func (h *HtpasswdFile) Reload() error {
 	}
 	users := make(map[string]string)
 	for _, record := range records {
+		if !validUsernameRegexp.MatchString(record[0]) {
+			log.Printf("Ignoring invalid username %q in htpasswd, consists of characters other than letters", record[0])
+			continue
+		}
 		users[record[0]] = record[1]
 	}
 


### PR DESCRIPTION
"/" is valid char in HTTP authorization headers, but are also used in
rest-server to map usernames to private repos.

This commit prevents loading maliciously composed usernames like
"/foo/config".

Issue: #131 

Checklist
---------

- [ ] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [x] I'm done, this Pull Request is ready for review
