### PR TITLE
Properly close CPU profile on SIGINT

### DIFF
--- a/cmd/rest-server/main.go
+++ b/cmd/rest-server/main.go
@@ -6,9 +6,11 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"runtime/pprof"
+	"syscall"
 
 	restserver "github.com/restic/rest-server"
 	"github.com/spf13/cobra"
@@ -109,7 +111,18 @@ func runRoot(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		log.Println("CPU profiling enabled")
-		defer pprof.StopCPUProfile()
+
+		// clean profiling shutdown on sigint
+		sigintCh := make(chan os.Signal, 1)
+		go func() {
+			for range sigintCh {
+				pprof.StopCPUProfile()
+				f.Close()
+				log.Println("Stopped CPU profiling")
+				os.Exit(130)
+			}
+		}()
+		signal.Notify(sigintCh, syscall.SIGINT)
 	}
 
 	handler, err := getHandler(server)


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
The rest server is normally shutdown via a SIGINT signal. The http handle calls are endless loops and don't return in the normal case. Thus add a signal handler to shutdown the profiler.

This prevents loosing the latest parts of the profiling log.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No.

Checklist
---------

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR~~
- ~~[ ] I have added documentation for the changes (in the manual)~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))~~ **Only relevant for developers**
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [x] I'm done, this Pull Request is ready for review
