### PR TITLE
Allow numbers in htpasswd usernames

### DIFF
--- a/changelog/unreleased/issue-131
+++ b/changelog/unreleased/issue-131
@@ -13,4 +13,5 @@ curl -v  -X DELETE -u foo/config:attack  http://localhost:8000/foo/config
 
 https://github.com/restic/rest-server/issues/131
 https://github.com/restic/rest-server/pull/132
+https://github.com/restic/rest-server/pull/137
 

--- a/htpasswd.go
+++ b/htpasswd.go
@@ -100,7 +100,7 @@ func (h *HtpasswdFile) throttleTimer() {
 	}
 }
 
-var validUsernameRegexp = regexp.MustCompile(`^[\p{L}@.-]+$`)
+var validUsernameRegexp = regexp.MustCompile(`^[\p{L}\d@.-]+$`)
 
 // Reload reloads the htpasswd file. If the reload fails, the Users map is not changed and the error is returned.
 func (h *HtpasswdFile) Reload() error {


### PR DESCRIPTION
TODO: Once PR #112 is merged, change this to used folderPathValid(), but let's merge this fix first.

What is the purpose of this change? What does it change?
--------------------------------------------------------

PR #132 added constraints on htpasswd usernames. As described in #134, this unintentionally disallows numbers.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #134 

Checklist
---------

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] ~~There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))~~ **-> updated existing file instead**
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [x] I'm done, this Pull Request is ready for review
