### PR TITLE
Cache basic auth credentials

### DIFF
--- a/changelog/unreleased/issue-133
+++ b/changelog/unreleased/issue-133
@@ -1,0 +1,9 @@
+Enhancement: Cache basic auth credentials
+
+To speed up the verification of basic auth credentials, rest-server now caches
+passwords for a minute in memory. That way the expensive verification of basic
+auth credentials can be skipped for most requests issued by a single restic
+run. The password is kept in memory in a hashed form and not as plaintext.
+
+https://github.com/restic/rest-server/issues/133
+https://github.com/restic/rest-server/pull/138

--- a/htpasswd.go
+++ b/htpasswd.go
@@ -254,7 +254,7 @@ func (h *HtpasswdFile) Validate(user string, password string) bool {
 	case shaRe.MatchString(realPassword):
 		d := sha1.New()
 		_, _ = d.Write([]byte(password))
-		if realPassword[5:] == base64.StdEncoding.EncodeToString(d.Sum(nil)) {
+		if subtle.ConstantTimeCompare([]byte(realPassword[5:]), []byte(base64.StdEncoding.EncodeToString(d.Sum(nil)))) == 1 {
 			isValid = true
 		}
 	case bcrRe.MatchString(realPassword):

--- a/htpasswd.go
+++ b/htpasswd.go
@@ -50,7 +50,7 @@ type HtpasswdFile struct {
 	path     string
 	stat     os.FileInfo
 	throttle chan struct{}
-	Users    map[string]string
+	users    map[string]string
 }
 
 // NewHtpasswdFromFile reads the users and passwords from a htpasswd file and returns them.  If an error is encountered,
@@ -130,7 +130,7 @@ func (h *HtpasswdFile) Reload() error {
 
 	// Replace the Users map
 	h.mutex.Lock()
-	h.Users = users
+	h.users = users
 	h.mutex.Unlock()
 
 	_ = r.Close()
@@ -178,7 +178,7 @@ func (h *HtpasswdFile) Validate(user string, password string) bool {
 	_ = h.ReloadCheck()
 
 	h.mutex.Lock()
-	realPassword, exists := h.Users[user]
+	realPassword, exists := h.users[user]
 	h.mutex.Unlock()
 
 	if !exists {

--- a/htpasswd.go
+++ b/htpasswd.go
@@ -211,6 +211,9 @@ func (h *HtpasswdFile) ReloadCheck() error {
 	return nil
 }
 
+var shaRe = regexp.MustCompile(`^{SHA}`)
+var bcrRe = regexp.MustCompile(`^\$2b\$|^\$2a\$|^\$2y\$`)
+
 // Validate returns true if password matches the stored password for user.  If no password for user is stored, or the
 // password is wrong, false is returned.
 func (h *HtpasswdFile) Validate(user string, password string) bool {
@@ -244,9 +247,6 @@ func (h *HtpasswdFile) Validate(user string, password string) bool {
 		h.mutex.Unlock()
 		return true
 	}
-
-	var shaRe = regexp.MustCompile(`^{SHA}`)
-	var bcrRe = regexp.MustCompile(`^\$2b\$|^\$2a\$|^\$2y\$`)
 
 	isValid := false
 

--- a/htpasswd.go
+++ b/htpasswd.go
@@ -234,6 +234,14 @@ func (h *HtpasswdFile) Validate(user string, password string) bool {
 	}
 
 	if cacheExists && subtle.ConstantTimeCompare(entry.verifier, hash.Sum(nil)) == 1 {
+		h.mutex.Lock()
+		// repurpose mutex to prevent concurrent cache updates
+		// extend cache entry
+		cache[user] = cacheEntry{
+			verifier: entry.verifier,
+			expiry:   time.Now().Add(PasswordCacheDuration),
+		}
+		h.mutex.Unlock()
 		return true
 	}
 

--- a/htpasswd_test.go
+++ b/htpasswd_test.go
@@ -1,0 +1,46 @@
+package restserver
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestValidate(t *testing.T) {
+	user := "restic"
+	pwd := "$2y$05$z/OEmNQamd6m6LSegUErh.r/Owk9Xwmc5lxDheIuHY2Z7XiS6FtJm"
+	rawPwd := "test"
+	wrongPwd := "wrong"
+
+	tmpfile, err := ioutil.TempFile("", "rest-validate-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = tmpfile.Write([]byte(user + ":" + pwd + "\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err = tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	htpass, err := NewHtpasswdFromFile(tmpfile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 10; i++ {
+		isValid := htpass.Validate(user, rawPwd)
+		if !isValid {
+			t.Fatal("correct password not accepted")
+		}
+
+		isValid = htpass.Validate(user, wrongPwd)
+		if isValid {
+			t.Fatal("wrong password accepted")
+		}
+	}
+
+	if err = os.Remove(tmpfile.Name()); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
As shown in #133 checking the basic auth credentials can substantially slow down the rest-server. The discussion there has also weighed the pros and cons of using separate auth tokens or just caching the credentials. This PR implements the latter variant as it is far simpler, and there's no obvious reason why a short-term cache would be a security issue.

The implementation tries to avoid introducing timing side-channels by ensuring that the control flow does not depend on the cached password. There's also an experimental commit which tries to overwrite expired cache entries.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes #133.

Checklist
---------

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual) **I'm not sure whether we should document this?**
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [x] I'm done, this Pull Request is ready for review
