### PR TITLE
Atomic file upload and directory sync

### DIFF
--- a/changelog/unreleased/pull-142
+++ b/changelog/unreleased/pull-142
@@ -1,0 +1,14 @@
+Bugfix: Fix possible data loss due to interrupted network connections
+
+When rest-server was run without `--append-only` it was possible to lose uploaded
+files in a specific scenario in which a network connection was interrupted. For the
+data loss to occur a file upload by restic would have to be interrupted such that
+restic notices the interrupted network connection before the rest-server. Then
+restic would have to retry the file upload and finish it before the rest-server
+notices that the initial upload has failed. Then the uploaded file would be
+accidentally removed by rest-server when trying to cleanup the failed upload.
+
+This has been fixed by always uploading to a temporary file first which is moved
+in position only once it was transfered completely.
+
+https://github.com/restic/rest-server/pull/142

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -224,8 +224,8 @@ func TestResticHandler(t *testing.T) {
 		{createOverwriteDeleteSeq(t, "/parent2/data/"+fileID, data)},
 	}
 
-	// setup rclone with a local backend in a temporary directory
-	tempdir, err := ioutil.TempDir("", "rclone-restic-test-")
+	// setup the server with a local backend in a temporary directory
+	tempdir, err := ioutil.TempDir("", "rest-server-test-")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -66,6 +66,7 @@ func newRequest(t testing.TB, method, path string, body io.Reader) *http.Request
 // wantCode returns a function which checks that the response has the correct HTTP status code.
 func wantCode(code int) wantFunc {
 	return func(t testing.TB, res *httptest.ResponseRecorder) {
+		t.Helper()
 		if res.Code != code {
 			t.Errorf("wrong response code, want %v, got %v", code, res.Code)
 		}
@@ -75,6 +76,7 @@ func wantCode(code int) wantFunc {
 // wantBody returns a function which checks that the response has the data in the body.
 func wantBody(body string) wantFunc {
 	return func(t testing.TB, res *httptest.ResponseRecorder) {
+		t.Helper()
 		if res.Body == nil {
 			t.Errorf("body is nil, want %q", body)
 			return
@@ -88,6 +90,7 @@ func wantBody(body string) wantFunc {
 
 // checkRequest uses f to process the request and runs the checker functions on the result.
 func checkRequest(t testing.TB, f http.HandlerFunc, req *http.Request, want []wantFunc) {
+	t.Helper()
 	rr := httptest.NewRecorder()
 	f(rr, req)
 

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -553,7 +553,8 @@ func (h *Handler) saveBlob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tf, err := ioutil.TempFile(filepath.Dir(path), ".rest-server-temp")
+	tmpFn := objectID + ".rest-server-temp"
+	tf, err := ioutil.TempFile(filepath.Dir(path), tmpFn)
 	if os.IsNotExist(err) {
 		// the error is caused by a missing directory, create it and retry
 		mkdirErr := os.MkdirAll(filepath.Dir(path), h.opt.DirMode)
@@ -561,7 +562,7 @@ func (h *Handler) saveBlob(w http.ResponseWriter, r *http.Request) {
 			log.Print(mkdirErr)
 		} else {
 			// try again
-			tf, err = ioutil.TempFile(filepath.Dir(path), ".rest-server-temp")
+			tf, err = ioutil.TempFile(filepath.Dir(path), tmpFn)
 		}
 	}
 	if err != nil {

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
@@ -637,6 +638,11 @@ func (h *Handler) saveBlob(w http.ResponseWriter, r *http.Request) {
 }
 
 func syncDir(dirname string) error {
+	if runtime.GOOS == "windows" {
+		// syncing a directory is not possible on windows
+		return nil
+	}
+
 	dir, err := os.Open(dirname)
 	if err != nil {
 		return err


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
This PR implements atomic uploads for blobs and also ensures that the directory entry for the blob is durably stored on disk.
Together with #130 this guarantees that uploaded blobs which are stored under their real filename are correct. Incomplete uploads or server crashes can at most cause the existence of incomplete temporary files.

The atomic uploads also solve a possible race condition during uploads, which can lead to missing pack files. That scenario could occur when the first upload fails partway and the server doesn't notice that immediately. A later retry by restic will then delete the broken upload and upload the file again. If the server now notices that the initial upload has failed, then it will delete the correctly uploaded file.

[Edit]
A design alternative to avoid the sketched race condition would be to use a per file lock to ensure that at most one concurrent modifying operation per path is possible. 
[/Edit]

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Partially in #130.

Checklist
---------

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- ~~[ ] I have added documentation for the changes (in the manual)~~ There's nothing to do for a user here.
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [x] I'm done, this Pull Request is ready for review
