### PR TITLE
docker: use bcrypt in create_users script

### DIFF
--- a/docker/create_user
+++ b/docker/create_user
@@ -9,8 +9,8 @@ fi
 
 if [ -z "$2" ]; then
     # password from prompt
-    htpasswd -s $PASSWORD_FILE $1
+    htpasswd -B $PASSWORD_FILE $1
 else
     # read password from command line
-    htpasswd -s -b $PASSWORD_FILE $1 $2
+    htpasswd -B -b $PASSWORD_FILE $1 $2
 fi


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
The create_users script should use bcrypt when hashing the password for new users. This was missed when adding bcrypt support in rest-server 0.9.7.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes #141.

Checklist
---------

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [x] I'm done, this Pull Request is ready for review
