### PR TITLE
Build restic at container build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,14 @@
+FROM golang:alpine AS builder
+
+ENV CGO_ENABLED 0
+
+COPY . /build
+WORKDIR /build
+RUN go build -o rest-server ./cmd/rest-server
+
+
+
+
 FROM alpine
 
 ENV DATA_DIRECTORY /data
@@ -8,7 +19,7 @@ RUN apk add --no-cache --update apache2-utils
 COPY docker/create_user /usr/bin/
 COPY docker/delete_user /usr/bin/
 COPY docker/entrypoint.sh /entrypoint.sh
-COPY rest-server /usr/bin
+COPY --from=builder /build/rest-server /usr/bin
 
 VOLUME /data
 EXPOSE 8000

--- a/README.md
+++ b/README.md
@@ -19,11 +19,15 @@ The required version of restic backup client to use with `rest-server` is [v0.7.
 
 For building the `rest-server` binary run `CGO_ENABLED=0 go build -o rest-server ./cmd/rest-server`
 
+
 ## Docker
 
 ### Build image
 
-Put the `rest-server` binary in the current directory, then run:
+The docker image build process will build a fresh version of the rest-server and package that into
+a usable container.
+
+To build the binary along with the container run:
 
     docker build -t restic/rest-server:latest .
 
@@ -31,6 +35,7 @@ Put the `rest-server` binary in the current directory, then run:
 ### Pull image
 
     docker pull restic/rest-server
+
 
 ## Usage
 

--- a/changelog/unreleased/issue-146
+++ b/changelog/unreleased/issue-146
@@ -1,5 +1,8 @@
-Build rest-server at docker container build time
+Change: Build rest-server at docker container build time
 
 Add a build stage such that the latest rest-server is always built and packaged.
 This is done in a standard golang container to ensure a clean build environment
 and only the final binary is shipped rather than the whole build environment.
+
+https://github.com/restic/rest-server/issues/146
+https://github.com/restic/rest-server/pull/145

--- a/changelog/unreleased/issue-146
+++ b/changelog/unreleased/issue-146
@@ -1,0 +1,5 @@
+Build rest-server at docker container build time
+
+Add a build stage such that the latest rest-server is always built and packaged.
+This is done in a standard golang container to ensure a clean build environment
+and only the final binary is shipped rather than the whole build environment.


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rest-server!

Please note that each PR should be preceded by an issue where the suggested
change can be discussed in general and without focus on specific code. That
way, work done in the PR will better match what's been agreed in the issue.

Please fill out the following questions to make it easier for us to review
your changes. You don't have to check all the checkboxes at once, instead
feel free to add more commits over time.
-->


What is the purpose of this change? What does it change?
--------------------------------------------------------

<!--
Describe the changes here, as detailed as needed.
-->

Using docker's multi-stage builds we can build the restic/rest-server
within a golang build environment then create a container for use
(without the build environment) in a second build stage.

The advantages are:

1. Building the rest-server is predictable in a pristine environment
   each time.
2. Container builds ensure we get the latest rest-server every time.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, write "Closes #1234" such
that the issue is closed automatically when this PR is merged.
-->

~~Not yet - will create an issue now.~~

https://github.com/restic/rest-server/issues/146


Checklist
---------

NOTE: I will go through this checklist as soon as possible to satisfy all the requirements.

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [x] I'm done, this Pull Request is ready for review
