### PR TITLE
Support running on demand via systemd

### DIFF
--- a/changelog/unreleased/issue-126
+++ b/changelog/unreleased/issue-126
@@ -1,0 +1,7 @@
+Feature: Allow running rest-server via systemd socket activation
+
+We've added the option to have systemd create the listening socket and start the rest-server on demand.
+
+https://github.com/restic/rest-server/issues/126
+https://github.com/restic/rest-server/pull/151
+https://github.com/restic/rest-server/pull/127

--- a/cmd/rest-server/listener_unix.go
+++ b/cmd/rest-server/listener_unix.go
@@ -1,0 +1,45 @@
+// +build !windows
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"net"
+
+	"github.com/coreos/go-systemd/activation"
+)
+
+// findListener tries to find a listener via systemd socket activation. If that
+// fails, it tries to create a listener on addr.
+func findListener(addr string) (listener net.Listener, err error) {
+	// try systemd socket activation
+	listeners, err := activation.Listeners()
+	if err != nil {
+		panic(err)
+	}
+
+	switch len(listeners) {
+	case 0:
+		// no listeners found, listen manually
+		listener, err = net.Listen("tcp", addr)
+		if err != nil {
+			return nil, fmt.Errorf("listen on %v failed: %w", addr, err)
+		}
+
+		log.Printf("start server on %v", addr)
+		return listener, nil
+
+	case 1:
+		// one listener supplied by systemd, use that one
+		//
+		// for testing, run rest-server with systemd-socket-activate as follows:
+		//
+		//    systemd-socket-activate -l 8080 ./rest-server
+		log.Printf("systemd socket activation mode")
+		return listeners[0], nil
+
+	default:
+		return nil, fmt.Errorf("got %d listeners from systemd, expected one", len(listeners))
+	}
+}

--- a/cmd/rest-server/listener_windows.go
+++ b/cmd/rest-server/listener_windows.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net"
+)
+
+// findListener creates a listener.
+func findListener(addr string) (listener net.Listener, err error) {
+	// listen manually
+	listener, err = net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("listen on %v failed: %w", addr, err)
+	}
+
+	log.Printf("start server on %v", addr)
+	return listener, nil
+}

--- a/cmd/rest-server/main.go
+++ b/cmd/rest-server/main.go
@@ -129,16 +129,17 @@ func runRoot(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if !enabledTLS {
-		log.Printf("Starting server on %s\n", server.Listen)
-		err = http.ListenAndServe(server.Listen, handler)
-	} else {
 
-		log.Println("TLS enabled")
-		log.Printf("Private key: %s", privateKey)
-		log.Printf("Public key(certificate): %s", publicKey)
-		log.Printf("Starting server on %s\n", server.Listen)
-		err = http.ListenAndServeTLS(server.Listen, publicKey, privateKey, handler)
+	listener, err := findListener(server.Listen)
+	if err != nil {
+		return fmt.Errorf("unable to listen: %w", err)
+	}
+
+	if !enabledTLS {
+		err = http.Serve(listener, handler)
+	} else {
+		log.Printf("TLS enabled, private key %s, pubkey %v", privateKey, publicKey)
+		err = http.ServeTLS(listener, handler, publicKey, privateKey)
 	}
 
 	return err

--- a/examples/systemd/rest-server.service
+++ b/examples/systemd/rest-server.service
@@ -3,6 +3,9 @@ Description=Rest Server
 After=syslog.target
 After=network.target
 
+# if you want to use socket activation, make sure to require the socket here
+#Requires=rest-server.socket
+
 [Service]
 Type=simple
 # You may prefer to use a different user or group on your system.

--- a/examples/systemd/rest-server.socket
+++ b/examples/systemd/rest-server.socket
@@ -1,0 +1,5 @@
+[Socket]
+ListenStream = 8080
+
+[Install]
+WantedBy = sockets.target

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/restic/rest-server
 go 1.14
 
 require (
+	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
 	github.com/felixge/httpsnoop v1.0.2 // indirect
 	github.com/gorilla/handlers v1.5.1
 	github.com/miolini/datacounter v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=
+github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rest-server!

Please note that each PR should be preceded by an issue where the suggested
change can be discussed in general and without focus on specific code. That
way, work done in the PR will better match what's been agreed in the issue.

Please fill out the following questions to make it easier for us to review
your changes. You don't have to check all the checkboxes at once, instead
feel free to add more commits over time.
-->


What is the purpose of this change? What does it change?
--------------------------------------------------------

This change allows `rest-server` to be run on demand by systemd (socket activation). The rationale for supporting both is as follows:

 1. On demand running with a listening socket opened externally is a good idea because then `rest-server` does not have to have the privileges to listen on a port.
 2. My first choice for that would be systemd (so the process can even be restricted further), but it is not available for non-Linux systems

<!--
Describe the changes here, as detailed as needed.
-->


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #126 
Supersedes #127

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, write "Closes #1234" such
that the issue is closed automatically when this PR is merged.
-->


Checklist
---------

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [x] I'm done, this Pull Request is ready for review
