### PR TITLE
Updated self-signed certificate creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,12 @@ NOTE: In older versions of rest-server (up to 0.9.7), this flag does not exist a
 
 By default the server uses HTTP protocol.  This is not very secure since with Basic Authentication, user name and passwords will be sent in clear text in every request.  In order to enable TLS support just add the `--tls` argument and add a private and public key at the root of your persistence directory. You may also specify private and public keys by `--tls-cert` and `--tls-key`.
 
-Signed certificate is required by the restic backend, but if you just want to test the feature you can generate unsigned keys with the following commands:
+Signed certificate is normally required by the restic backend, but if you just want to test the feature you can generate unsigned keys with the following commands:
 
     openssl genrsa -out private_key 2048
-    openssl req -new -x509 -key private_key -out public_key -days 365
+    openssl req -new -x509 -key private_key -out public_key -days 365 -addext "subjectAltName = IP:127.0.0.1,DNS:yourdomain.com"
+    
+Omit the `IP:127.0.0.1` if you don't need your server be accessed via SSH Tunnels. No need to change default values in the openssl dialog, hitting enter every time is sufficient. To access this server via restic use `--cacert public_key`, meaning with a self-signed certificate you have to distribute your `public_key` file to every restic client.  
 
 The `--append-only` mode allows creation of new backups but prevents deletion and modification of existing backups. This can be useful when backing up systems that have a potential of being hacked.
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rest-server!

Please note that each PR should be preceded by an issue where the suggested
change can be discussed in general and without focus on specific code. That
way, work done in the PR will better match what's been agreed in the issue.

Please fill out the following questions to make it easier for us to review
your changes. You don't have to check all the checkboxes at once, instead
feel free to add more commits over time.
-->


What is the purpose of this change? What does it change?
--------------------------------------------------------

<!--
Describe the changes here, as detailed as needed.
-->
It updates the tutorial for creating self-signed certificates. Without this change restic 0.12.0 compiled with go1.15.8 on windows/amd64 will fail to connect to your restic server, even with `--cacert` option. Error messages are, depending on what entered at `Common name` in the openssl dialog:
Entering nothing or `*`: `x509: certificate is not valid for any names, but wanted to match yourdomain.com`
Entering `yourdomain.com`: `x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0`

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, write "Closes #1234" such
that the issue is closed automatically when this PR is merged.
-->
No. I've played around until I've figured it out to get it working.

Checklist
---------

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [x] I'm done, this Pull Request is ready for review

Since this is only a documentation update no functionality is changed at all.