### PR TITLE
Use os.TempDir() for temporary directory in default path

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Flags:
   -v, --version              version for rest-server
 ```
 
-By default the server persists backup data in the O.S. temporary directory (`/tmp/restic` on Linux/BSD and others, in `%TEMP%\\restic` in Windows, etc). **If `rest-server` is launched using the default path, all backups will be lost**. To start the server with a custom persistence directory and with authentication disabled:
+By default the server persists backup data in the OS temporary directory (`/tmp/restic` on Linux/BSD and others, in `%TEMP%\\restic` in Windows, etc). **If `rest-server` is launched using the default path, all backups will be lost**. To start the server with a custom persistence directory and with authentication disabled:
 
 ```sh
 rest-server --path /user/home/backup --no-auth

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Flags:
   -v, --version              version for rest-server
 ```
 
-By default the server persists backup data in `/tmp/restic`.  To start the server with a custom persistence directory and with authentication disabled:
+By default the server persists backup data in the O.S. temporary directory (`/tmp/restic` on Linux/BSD and others, in `%TEMP%\\restic` in Windows, etc). **If `rest-server` is launched using the default path, all backups will be lost**. To start the server with a custom persistence directory and with authentication disabled:
 
 ```sh
 rest-server --path /user/home/backup --no-auth

--- a/changelog/unreleased/pull-158
+++ b/changelog/unreleased/pull-158
@@ -1,0 +1,8 @@
+Bugfix: Use platform-specific temporary directory in default path
+
+Instead of using hardcoded value for temporary directory, rest-server now uses
+Go standard library functions to retrieve the temporary directory path for the
+current platform.
+
+https://github.com/restic/rest-server/issues/157
+https://github.com/restic/rest-server/pull/158

--- a/cmd/rest-server/main.go
+++ b/cmd/rest-server/main.go
@@ -27,7 +27,7 @@ var cmdRoot = &cobra.Command{
 }
 
 var server = restserver.Server{
-	Path:   "/tmp/restic",
+	Path:   filepath.Join(os.TempDir(), "restic"),
 	Listen: ":8000",
 }
 


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

This pull request removes the hardcoded reference to `/tmp/restic` replacing with platform-specific path, retrieved using `os.TempDir()` stdlib function.


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Issue #157 


Checklist
---------

- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- I have added tests for all changes in this PR
   - No need for test, `os.TempDir()` is a builtin function
- [X] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [x] I'm done, this Pull Request is ready for review
