### PR TITLE
Reply "insufficient storage" on disk full or over-quota

### DIFF
--- a/changelog/unreleased/pull-160
+++ b/changelog/unreleased/pull-160
@@ -1,0 +1,13 @@
+Bugfix: Reply "insufficient storage" on disk full or over-quota
+
+When there was no space left on disk, or any other write-related error,
+rest-server was replying with HTTP status code 400 (Bad request). This is
+misleading (restic client will dump the status code to the user).
+
+This has been fixed changing the behaviour so two different statuses are used:
+* HTTP 507 "Insufficient storage" is the status on disk full or repository
+  over-quota
+* HTTP 500 "Internal server error" on other disk-related errors
+
+https://github.com/restic/rest-server/issues/155
+https://github.com/restic/rest-server/pull/160

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -397,7 +396,7 @@ func TestAbortedRequest(t *testing.T) {
 
 	// the first request is an upload to a file which blocks while reading the
 	// body and then after some data returns an error
-	rd := newDelayedErrorReader(errors.New("injected"))
+	rd := newDelayedErrorReader(io.ErrUnexpectedEOF)
 
 	wg.Add(1)
 	go func() {

--- a/quota/quota.go
+++ b/quota/quota.go
@@ -75,7 +75,7 @@ func (m *Manager) WrapWriter(req *http.Request, w io.Writer) (io.Writer, int, er
 		if currentSize+contentLen > m.maxRepoSize {
 			err := fmt.Errorf("incoming blob (%d bytes) would exceed maximum size of repository (%d bytes)",
 				contentLen, m.maxRepoSize)
-			return nil, http.StatusRequestEntityTooLarge, err
+			return nil, http.StatusInsufficientStorage, err
 		}
 	}
 

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -85,6 +85,10 @@ func httpMethodNotAllowed(w http.ResponseWriter, allowed []string) {
 	httpDefaultError(w, http.StatusMethodNotAllowed)
 }
 
+// errFileContentDoesntMatchHash is the error raised when the file content hash
+// doesn't match the hash provided in the URL
+var errFileContentDoesntMatchHash = errors.New("file content does not match hash")
+
 // BlobPathRE matches valid blob URI paths with optional object IDs
 var BlobPathRE = regexp.MustCompile(`^/(data|index|keys|locks|snapshots)/([0-9a-f]{64})?$`)
 
@@ -594,7 +598,7 @@ func (h *Handler) saveBlob(w http.ResponseWriter, r *http.Request) {
 
 		// reject if file content doesn't match file name
 		if err == nil && hex.EncodeToString(hasher.Sum(nil)) != objectID {
-			err = fmt.Errorf("file content does not match hash")
+			err = errFileContentDoesntMatchHash
 		}
 	}
 
@@ -606,10 +610,21 @@ func (h *Handler) saveBlob(w http.ResponseWriter, r *http.Request) {
 			log.Print(err)
 		}
 		var pathError *os.PathError
-		if errors.As(err, &pathError) && (pathError.Err == syscall.ENOSPC || pathError.Err == syscall.EDQUOT) {
+		if errors.As(err, &pathError) && (pathError.Err == syscall.ENOSPC ||
+			pathError.Err == syscall.EDQUOT) {
+			// The error is disk-related (no space left, no quota left),
+			// notify the client using the correct HTTP status
 			httpDefaultError(w, http.StatusInsufficientStorage)
+		} else if errors.Is(err, errFileContentDoesntMatchHash) ||
+			errors.Is(err, io.ErrUnexpectedEOF) ||
+			errors.Is(err, http.ErrMissingBoundary) ||
+			errors.Is(err, http.ErrNotMultipart) {
+			// The error is connection-related, send a client-side HTTP status
+			httpDefaultError(w, http.StatusBadRequest)
 		} else {
-			httpDefaultError(w, http.StatusInternalServerError)
+			// Otherwise we have a different internal error, reply with
+			// server-side HTTP status
+			h.internalServerError(w, err)
 		}
 		return
 	}


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to rest-server!

Please note that each PR should be preceded by an issue where the suggested
change can be discussed in general and without focus on specific code. That
way, work done in the PR will better match what's been agreed in the issue.

Please fill out the following questions to make it easier for us to review
your changes. You don't have to check all the checkboxes at once, instead
feel free to add more commits over time.
-->


What is the purpose of this change? What does it change?
--------------------------------------------------------

This pull request will change the current behavior on disk-related errors:
* HTTP 507 "Insufficient storage" is the status on disk full or over-quota
* HTTP 500 "Internal server error" on other disk-related errors

Previously both were 400 "Bad request"


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Issue: https://github.com/restic/rest-server/issues/155


Checklist
---------

- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [x] I'm done, this Pull Request is ready for review
