### PR TITLE
Config: Read in PrometheusNoAuth correctly

### DIFF
--- a/cmd/rest-server/main.go
+++ b/cmd/rest-server/main.go
@@ -52,7 +52,7 @@ func init() {
 	flags.BoolVar(&server.AppendOnly, "append-only", server.AppendOnly, "enable append only mode")
 	flags.BoolVar(&server.PrivateRepos, "private-repos", server.PrivateRepos, "users can only access their private repo")
 	flags.BoolVar(&server.Prometheus, "prometheus", server.Prometheus, "enable Prometheus metrics")
-	flags.BoolVar(&server.Prometheus, "prometheus-no-auth", server.PrometheusNoAuth, "disable auth for Prometheus /metrics endpoint")
+	flags.BoolVar(&server.PrometheusNoAuth, "prometheus-no-auth", server.PrometheusNoAuth, "disable auth for Prometheus /metrics endpoint")
 }
 
 var version = "0.10.0-dev"


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rest-server!

Please note that each PR should be preceded by an issue where the suggested
change can be discussed in general and without focus on specific code. That
way, work done in the PR will better match what's been agreed in the issue.

Please fill out the following questions to make it easier for us to review
your changes. You don't have to check all the checkboxes at once, instead
feel free to add more commits over time.
-->


What is the purpose of this change? What does it change?
--------------------------------------------------------

<!--
Describe the changes here, as detailed as needed.
-->

This change addresses an issue in which the value of the `--prometheus-no-auth` flag actually got applied to the value of `--prometheus` when reading in flags.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, write "Closes #1234" such
that the issue is closed automatically when this PR is merged.
-->

Issue was introduced in #112 alongside the inital implementation for `--prometheus-no-auth`

Checklist
---------

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual): See below
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE)): Unsure if this is needed due to just fixing an implementation issue self contained in unreleased
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master): Unsure, commit style inconsistent
- [x] I'm done, this Pull Request is ready for review
