### PR TITLE
Allow underscores in usernames

### DIFF
--- a/changelog/unreleased/issue-182
+++ b/changelog/unreleased/issue-182
@@ -1,0 +1,8 @@
+Bugfix: Allow usernames containing underscore
+
+The security fix in rest-server 0.11.0 (#131) disallowed usernames containing
+and underscore "_". We have changed the list of allowed characters to now include
+unicode characters, numbers, "_", "-", "." and "@".
+
+https://github.com/restic/restic/issues/183
+https://github.com/restic/restic/pull/184

--- a/htpasswd.go
+++ b/htpasswd.go
@@ -100,7 +100,7 @@ func (h *HtpasswdFile) throttleTimer() {
 	}
 }
 
-var validUsernameRegexp = regexp.MustCompile(`^[\p{L}\d@.-]+$`)
+var validUsernameRegexp = regexp.MustCompile(`^[\p{L}\d@._-]+$`)
 
 // Reload reloads the htpasswd file. If the reload fails, the Users map is not changed and the error is returned.
 func (h *HtpasswdFile) Reload() error {
@@ -122,7 +122,7 @@ func (h *HtpasswdFile) Reload() error {
 	users := make(map[string]string)
 	for _, record := range records {
 		if !validUsernameRegexp.MatchString(record[0]) {
-			log.Printf("Ignoring invalid username %q in htpasswd, consists of characters other than letters", record[0])
+			log.Printf("Ignoring invalid username %q in htpasswd, consists of characters other than letters, numbers, '_', '-', '.' and '@'", record[0])
 			continue
 		}
 		users[record[0]] = record[1]


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
Allow usernames containing underscore again, after they were forbidden by #131.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes #182 

Checklist
---------

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [x] I'm done, this Pull Request is ready for review
