### PR TITLE
Be more clear in --help what the value of --log is supposed to be

### DIFF
--- a/cmd/rest-server/main.go
+++ b/cmd/rest-server/main.go
@@ -40,7 +40,7 @@ func init() {
 	flags.StringVar(&cpuProfile, "cpu-profile", cpuProfile, "write CPU profile to file")
 	flags.BoolVar(&server.Debug, "debug", server.Debug, "output debug messages")
 	flags.StringVar(&server.Listen, "listen", server.Listen, "listen address")
-	flags.StringVar(&server.Log, "log", server.Log, "log HTTP requests in the combined log format")
+	flags.StringVar(&server.Log, "log", server.Log, "write HTTP requests in the combined log format to the specified `filename`")
 	flags.Int64Var(&server.MaxRepoSize, "max-size", server.MaxRepoSize, "the maximum size of the repository in bytes")
 	flags.StringVar(&server.Path, "path", server.Path, "data directory")
 	flags.BoolVar(&server.TLS, "tls", server.TLS, "turn on TLS support")


### PR DESCRIPTION
Currently, `--help` says:

    ...
       --listen string        listen address (default ":8000")
       --log string           log HTTP requests in the combined log format
       --max-size int         the maximum size of the repository in bytes
    ...

I looked through the documentation and even gave the source code a glance to find what this "string" is supposed to be, which options exist? I just want it to dump the URI or something, whatever the syntax is for that in this combined format, why is an argument even required and can't I use some default?

Some `%s`-like guesses later and not seeing any log messages at all upon doing requests to the server, I moved on and did an `ls` for unrelated reasons, finding that it had created my attempts as filenames. *Aha, it has to be a filename! It doesn't simply log to stdout!*

This pull request hopefully makes that more clear for those who come after me. I found it hard to find good phrasing without making it overly long. I'd actually rather replace the word "string" with "filename" (or just "file") and leave the rest as-is, but I'm not sure if that's possible without overcomplicating things.

The proposed change would appear as:

    ...
       --listen string        listen address (default ":8000")
       --log string           write HTTP requests in the combined log format to the specified filename
       --max-size int         the maximum size of the repository in bytes
    ...

The `--no-verify-upload` option is the only one that is still (significantly) longer, but it's also a bit of an exception so that's not a great measure.

(If a changelog entry is needed for this change, just let me now. I've marked it as not applicable in the checklist because it seems too trivial for an entry.)

Checklist
---------

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- n/a I have added tests for all changes in this PR
- n/a I have added documentation for the changes (in the manual)
- n/a There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [x] I'm done, this Pull Request is ready for review
