### PR TITLE
Add 'write-only' mode

### DIFF
--- a/cmd/rest-server/main.go
+++ b/cmd/rest-server/main.go
@@ -49,7 +49,8 @@ func init() {
 	flags.BoolVar(&server.NoAuth, "no-auth", server.NoAuth, "disable .htpasswd authentication")
 	flags.BoolVar(&server.NoVerifyUpload, "no-verify-upload", server.NoVerifyUpload,
 		"do not verify the integrity of uploaded data. DO NOT enable unless the rest-server runs on a very low-power device")
-	flags.BoolVar(&server.AppendOnly, "append-only", server.AppendOnly, "enable append only mode")
+	flags.BoolVar(&server.AppendOnly, "append-only", server.AppendOnly, "enable append only mode (disables delete)")
+	flags.BoolVar(&server.WriteOnly, "write-only", server.WriteOnly, "enable write only mode (disables delete and restore)")
 	flags.BoolVar(&server.PrivateRepos, "private-repos", server.PrivateRepos, "users can only access their private repo")
 	flags.BoolVar(&server.Prometheus, "prometheus", server.Prometheus, "enable Prometheus metrics")
 	flags.BoolVar(&server.PrometheusNoAuth, "prometheus-no-auth", server.PrometheusNoAuth, "disable auth for Prometheus /metrics endpoint")

--- a/handlers.go
+++ b/handlers.go
@@ -23,6 +23,7 @@ type Server struct {
 	TLS              bool
 	NoAuth           bool
 	AppendOnly       bool
+	WriteOnly        bool
 	PrivateRepos     bool
 	Prometheus       bool
 	PrometheusNoAuth bool
@@ -86,6 +87,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Pass the request to the repo.Handler
 	opt := repo.Options{
 		AppendOnly:     s.AppendOnly,
+		WriteOnly:      s.WriteOnly,
 		Debug:          s.Debug,
 		QuotaManager:   s.quotaManager, // may be nil
 		PanicOnError:   s.PanicOnError,


### PR DESCRIPTION
Write-only mode allows only backup. So there is no way to read data from repo (except metadata)


What is the purpose of this change? What does it change?
--------------------------------------------------------

Currently we've `--append-only` mode that tries to minimize risks if machine where `restic` is launched is compromised. Basically it makes sure that attacker can't delete existing data from snapshot.

This adds `--write-only` mode that also disables 'restore' of existing data from repository. If repository is shared to save space, attacker can't get data that was uploaded from other systems.

I know that `restic` threat mode assumes that backup host is trusted, but `append-only` here is in exactly same situation.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
#110 

Checklist
---------

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [ ] I'm done, this Pull Request is ready for review
