### PR TITLE
Return "internal server error" if files cannot be read

### DIFF
--- a/changelog/unreleased/pull-194
+++ b/changelog/unreleased/pull-194
@@ -1,0 +1,13 @@
+Bugfix: Return "internal server error" if files cannot be read
+
+When files in a repository cannot be read by rest-server, for example after
+running `restic prune` directly on the server hosting the repositories, then
+rest-server returned "Not Found" as status code. This is extremely confusing
+for users.
+
+The error handling has been fixed to only return "Not Found" if the file
+actually does not exist. Otherwise an internal server error is reported to the
+user and the underlying error is logged at the server side.
+
+https://github.com/restic/restic/issues/1871
+https://github.com/restic/rest-server/pull/194

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -257,10 +257,7 @@ func (h *Handler) checkConfig(w http.ResponseWriter, r *http.Request) {
 
 	st, err := os.Stat(cfg)
 	if err != nil {
-		if h.opt.Debug {
-			log.Print(err)
-		}
-		httpDefaultError(w, http.StatusNotFound)
+		h.fileAccessError(w, err)
 		return
 	}
 
@@ -276,10 +273,7 @@ func (h *Handler) getConfig(w http.ResponseWriter, r *http.Request) {
 
 	bytes, err := ioutil.ReadFile(cfg)
 	if err != nil {
-		if h.opt.Debug {
-			log.Print(err)
-		}
-		httpDefaultError(w, http.StatusNotFound)
+		h.fileAccessError(w, err)
 		return
 	}
 
@@ -331,14 +325,7 @@ func (h *Handler) deleteConfig(w http.ResponseWriter, r *http.Request) {
 	cfg := h.getSubPath("config")
 
 	if err := os.Remove(cfg); err != nil {
-		if h.opt.Debug {
-			log.Print(err)
-		}
-		if os.IsNotExist(err) {
-			httpDefaultError(w, http.StatusNotFound)
-		} else {
-			h.internalServerError(w, err)
-		}
+		h.fileAccessError(w, err)
 		return
 	}
 }
@@ -378,10 +365,7 @@ func (h *Handler) listBlobsV1(w http.ResponseWriter, r *http.Request) {
 
 	items, err := ioutil.ReadDir(path)
 	if err != nil {
-		if h.opt.Debug {
-			log.Print(err)
-		}
-		httpDefaultError(w, http.StatusNotFound)
+		h.fileAccessError(w, err)
 		return
 	}
 
@@ -392,10 +376,7 @@ func (h *Handler) listBlobsV1(w http.ResponseWriter, r *http.Request) {
 			var subitems []os.FileInfo
 			subitems, err = ioutil.ReadDir(subpath)
 			if err != nil {
-				if h.opt.Debug {
-					log.Print(err)
-				}
-				httpDefaultError(w, http.StatusNotFound)
+				h.fileAccessError(w, err)
 				return
 			}
 			for _, f := range subitems {
@@ -439,10 +420,7 @@ func (h *Handler) listBlobsV2(w http.ResponseWriter, r *http.Request) {
 
 	items, err := ioutil.ReadDir(path)
 	if err != nil {
-		if h.opt.Debug {
-			log.Print(err)
-		}
-		httpDefaultError(w, http.StatusNotFound)
+		h.fileAccessError(w, err)
 		return
 	}
 
@@ -453,10 +431,7 @@ func (h *Handler) listBlobsV2(w http.ResponseWriter, r *http.Request) {
 			var subitems []os.FileInfo
 			subitems, err = ioutil.ReadDir(subpath)
 			if err != nil {
-				if h.opt.Debug {
-					log.Print(err)
-				}
-				httpDefaultError(w, http.StatusNotFound)
+				h.fileAccessError(w, err)
 				return
 			}
 			for _, f := range subitems {
@@ -493,10 +468,7 @@ func (h *Handler) checkBlob(w http.ResponseWriter, r *http.Request) {
 
 	st, err := os.Stat(path)
 	if err != nil {
-		if h.opt.Debug {
-			log.Print(err)
-		}
-		httpDefaultError(w, http.StatusNotFound)
+		h.fileAccessError(w, err)
 		return
 	}
 
@@ -519,10 +491,7 @@ func (h *Handler) getBlob(w http.ResponseWriter, r *http.Request) {
 
 	file, err := os.Open(path)
 	if err != nil {
-		if h.opt.Debug {
-			log.Print(err)
-		}
-		httpDefaultError(w, http.StatusNotFound)
+		h.fileAccessError(w, err)
 		return
 	}
 
@@ -721,14 +690,7 @@ func (h *Handler) deleteBlob(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := os.Remove(path); err != nil {
-		if h.opt.Debug {
-			log.Print(err)
-		}
-		if os.IsNotExist(err) {
-			httpDefaultError(w, http.StatusNotFound)
-		} else {
-			h.internalServerError(w, err)
-		}
+		h.fileAccessError(w, err)
 		return
 	}
 
@@ -770,7 +732,7 @@ func (h *Handler) createRepo(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// internalServerError is called to repot an internal server error.
+// internalServerError is called to report an internal server error.
 // The error message will be reported in the server logs. If PanicOnError
 // is set, this will panic instead, which makes debugging easier.
 func (h *Handler) internalServerError(w http.ResponseWriter, err error) {
@@ -779,4 +741,19 @@ func (h *Handler) internalServerError(w http.ResponseWriter, err error) {
 		panic(fmt.Sprintf("internal server error: %v", err))
 	}
 	httpDefaultError(w, http.StatusInternalServerError)
+}
+
+// internalServerError is called to report an error that occurred while
+// accessing a file. If the does not exist, the corresponding http status code
+// will be returned to the client. All other errors are passed on to
+// internalServerError
+func (h *Handler) fileAccessError(w http.ResponseWriter, err error) {
+	if h.opt.Debug {
+		log.Print(err)
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		httpDefaultError(w, http.StatusNotFound)
+	} else {
+		h.internalServerError(w, err)
+	}
 }

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -325,7 +325,11 @@ func (h *Handler) deleteConfig(w http.ResponseWriter, r *http.Request) {
 	cfg := h.getSubPath("config")
 
 	if err := os.Remove(cfg); err != nil {
-		h.fileAccessError(w, err)
+		// ignore not exist errors to make deleting idempotent, which is
+		// necessary to properly handle request retries
+		if !errors.Is(err, os.ErrNotExist) {
+			h.fileAccessError(w, err)
+		}
 		return
 	}
 }
@@ -690,7 +694,11 @@ func (h *Handler) deleteBlob(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := os.Remove(path); err != nil {
-		h.fileAccessError(w, err)
+		// ignore not exist errors to make deleting idempotent, which is
+		// necessary to properly handle request retries
+		if !errors.Is(err, os.ErrNotExist) {
+			h.fileAccessError(w, err)
+		}
 		return
 	}
 


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
When files in a repository cannot be read by rest-server, for example after running `restic prune` directly on the server hosting the repositories, then rest-server returned "Not Found" as status code. This is extremely confusing for users.

The PR fixes the error handling when files cannot be accessed. If the returned error is `fs.ErrNotExist` then it is turned into a "Not Found" status code, all other errors now result in an "Internal Error" together with a debug log output.


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes https://github.com/restic/restic/issues/1871
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, write "Closes #1234" such
that the issue is closed automatically when this PR is merged.
-->


Checklist
---------

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [x] I'm done, this Pull Request is ready for review
