### PR TITLE
Ignore fsync errors

### DIFF
--- a/repo/repo_unix.go
+++ b/repo/repo_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+// +build !windows
+
+package repo
+
+import (
+	"errors"
+	"runtime"
+	"syscall"
+)
+
+// The ExFAT driver on some versions of macOS can return ENOTTY,
+// "inappropriate ioctl for device", for fsync.
+//
+// https://github.com/restic/restic/issues/4016
+// https://github.com/realm/realm-core/issues/5789
+func isMacENOTTY(err error) bool {
+	return runtime.GOOS == "darwin" && errors.Is(err, syscall.ENOTTY)
+}

--- a/repo/repo_windows.go
+++ b/repo/repo_windows.go
@@ -1,0 +1,4 @@
+package repo
+
+// Windows is not macOS.
+func isMacENOTTY(err error) bool { return false }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rest-server!

Please note that each PR should be preceded by an issue where the suggested
change can be discussed in general and without focus on specific code. That
way, work done in the PR will better match what's been agreed in the issue.

Please fill out the following questions to make it easier for us to review
your changes. You don't have to check all the checkboxes at once, instead
feel free to add more commits over time.
-->


What is the purpose of this change? What does it change?
--------------------------------------------------------
Storing a repository on a filesystem that does not support fsync is currently not possible. This PR syncs the ignored fsync errors from the restic backend to also allow storing a repository on these filesystems. However, this is not recommended as without fsync it is not possible to guarantee the integrity of uploaded data.

In addition, macOS Ventura seems to have introduced an additional error code, see #198.
<!--
Describe the changes here, as detailed as needed.
-->


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes #198.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, write "Closes #1234" such
that the issue is closed automatically when this PR is merged.
-->


Checklist
---------

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [ ] I'm done, this Pull Request is ready for review
