### PR TITLE
Make dashboard portable

### DIFF
--- a/examples/compose-with-grafana/dashboards/rest-server.json
+++ b/examples/compose-with-grafana/dashboards/rest-server.json
@@ -1,4 +1,14 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS-INFRA",
+      "label": "prometheus-infra",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
   "__requires": [
     {
       "type": "grafana",
@@ -12,7 +22,7 @@
       "name": "Graph",
       "version": ""
     },
-    {
+	{
       "type": "datasource",
       "id": "prometheus",
       "name": "Prometheus",
@@ -49,7 +59,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "prometheus",
+		  "datasource": "${DS_PROMETHEUS-INFRA}",
           "fill": 1,
           "id": 1,
           "legend": {
@@ -125,7 +135,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "prometheus",
+		  "datasource": "${DS_PROMETHEUS-INFRA}",
           "fill": 1,
           "id": 4,
           "legend": {
@@ -213,7 +223,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "prometheus",
+		  "datasource": "${DS_PROMETHEUS-INFRA}",
           "fill": 1,
           "id": 2,
           "legend": {
@@ -289,7 +299,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "prometheus",
+		  "datasource": "${DS_PROMETHEUS-INFRA}",
           "fill": 1,
           "id": 5,
           "legend": {
@@ -377,7 +387,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "prometheus",
+		  "datasource": "${DS_PROMETHEUS-INFRA}",
           "fill": 1,
           "id": 3,
           "legend": {
@@ -453,7 +463,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "prometheus",
+		  "datasource": "${DS_PROMETHEUS-INFRA}",
           "fill": 1,
           "id": 6,
           "legend": {
@@ -541,7 +551,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "prometheus",
+		"datasource": "${DS_PROMETHEUS-INFRA}",
         "hide": 0,
         "includeAll": false,
         "label": "Instance",


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
Allows to select datasource when first importing into grafana, thus making the dashboard portable.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Don't think this was discussed anywhere

Checklist
---------

- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [N/A] I have added tests for all changes in this PR
- [N/A] I have added documentation for the changes (in the manual)
- [N/A] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [N/A] I have run `gofmt` on the code in all commits
- [N/A] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [X] I'm done, this Pull Request is ready for review
