### PR TITLE
Error out on unexpected command line argument

### DIFF
--- a/changelog/unreleased/pull-207
+++ b/changelog/unreleased/pull-207
@@ -1,0 +1,5 @@
+Change: Return error if command-line arguments are specified
+
+The rest-server ignores command-line arguments. To prevent usage errors it not fails with an error instead of silently ignoring the arguments.
+
+https://github.com/restic/rest-server/pull/207

--- a/cmd/rest-server/main.go
+++ b/cmd/rest-server/main.go
@@ -23,7 +23,13 @@ var cmdRoot = &cobra.Command{
 	SilenceErrors: true,
 	SilenceUsage:  true,
 	RunE:          runRoot,
-	Version:       fmt.Sprintf("rest-server %s compiled with %v on %v/%v\n", version, runtime.Version(), runtime.GOOS, runtime.GOARCH),
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 0 {
+			return fmt.Errorf("rest-server expects no arguments - unknown argument: %s", args[0])
+		}
+		return nil
+	},
+	Version: fmt.Sprintf("rest-server %s compiled with %v on %v/%v\n", version, runtime.Version(), runtime.GOOS, runtime.GOARCH),
 }
 
 var server = restserver.Server{


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
rest-server doesn't accept arguments. Thus, error out to prevent wrong usage.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Fixes https://github.com/restic/rest-server/issues/206

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, write "Closes #1234" such
that the issue is closed automatically when this PR is merged.
-->


Checklist
---------

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [x] I'm done, this Pull Request is ready for review
