### PR TITLE
warn about SystemCallArchitectures in the systemd service

### DIFF
--- a/examples/systemd/rest-server.service
+++ b/examples/systemd/rest-server.service
@@ -54,6 +54,7 @@ RestrictNamespaces=true
 RestrictAddressFamilies=AF_INET AF_INET6
 RestrictSUIDSGID=true
 RestrictRealtime=true
+# if your service crashes with "code=killed, status=31/SYS", you probably tried to run linux_i386 (32bit) binary on a amd64 host
 SystemCallArchitectures=native
 SystemCallFilter=@system-service
 


### PR DESCRIPTION
Running 32bit on a 64bit host with SystemCallArchitectures will fail without much information

<!--
Thank you very much for contributing code or documentation to rest-server!

Please note that each PR should be preceded by an issue where the suggested
change can be discussed in general and without focus on specific code. That
way, work done in the PR will better match what's been agreed in the issue.

Please fill out the following questions to make it easier for us to review
your changes. You don't have to check all the checkboxes at once, instead
feel free to add more commits over time.
-->

I didn't expect this to require a real issue. It's just me trying to debug a non-start restic-server for 1h, simply because I didn't see an amd64 built was available - github collapses the release artifacts due to the amount - and the "native" setting in the default service unit will create weird crashes.
Effectively you get 0 information, it just crashes with `code=killed, status=31/SYS` (which is true for anything running into filtered system calls).

What is the purpose of this change? What does it change?
--------------------------------------------------------

<!--
Describe the changes here, as detailed as needed.
-->
Add some note about a possibly weird failure of running rest-server with the systemd unit, when trying to run the i386 binary on amd64

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, write "Closes #1234" such
that the issue is closed automatically when this PR is merged.
-->
No


Checklist
---------

- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [X] I'm done, this Pull Request is ready for review
