### PR TITLE
feat: allow logging to stdout, stderr

### DIFF
--- a/changelog/unreleased/pull-217
+++ b/changelog/unreleased/pull-217
@@ -1,13 +1,13 @@
-Feature: Allows "-" as filename for the `--log` option.
+Feature: Log to stdout using the `--log -` option
 
-When (e.g. for debugging purpose) the rest server is invoked like
+Logging to stdout was possible using `--log /dev/stdout`. However,
+when the rest server is run as a different user, for example, using
 
-	sudo -u restic rest-server … --log /dev/stdout
+	`sudo -u restic rest-server [...] --log /dev/stdout`
 
-it tries to open `/dev/stdout` (O_CREATE, O_WRITE, O_APPEND). This
-operation fails, as in the above invocation, `/dev/stdout` is owned by
-the caller (here: root) and only writable for the caller. Subprocesses
-get just the filedescriptor. Using `/proc/self/fd/1` didn't work either,
-for the same reasons.
+this did not work due to permission issues.
+
+For logging to stdout, the `--log` option now supports the special
+filename `-` which also works in these cases.
 
 https://github.com/restic/rest-server/pull/217

--- a/changelog/unreleased/pull-217
+++ b/changelog/unreleased/pull-217
@@ -1,0 +1,13 @@
+Feature: Allows "-" as filename for the `--log` option.
+
+When (e.g. for debugging purpose) the rest server is invoked like
+
+	sudo -u restic rest-server … --log /dev/stdout
+
+it tries to open `/dev/stdout` (O_CREATE, O_WRITE, O_APPEND). This
+operation fails, as in the above invocation, `/dev/stdout` is owned by
+the caller (here: root) and only writable for the caller. Subprocesses
+get just the filedescriptor. Using `/proc/self/fd/1` didn't work either,
+for the same reasons.
+
+https://github.com/restic/rest-server/pull/217

--- a/cmd/rest-server/main.go
+++ b/cmd/rest-server/main.go
@@ -46,7 +46,7 @@ func init() {
 	flags.StringVar(&cpuProfile, "cpu-profile", cpuProfile, "write CPU profile to file")
 	flags.BoolVar(&server.Debug, "debug", server.Debug, "output debug messages")
 	flags.StringVar(&server.Listen, "listen", server.Listen, "listen address")
-	flags.StringVar(&server.Log, "log", server.Log, "write HTTP requests in the combined log format to the specified `filename`")
+	flags.StringVar(&server.Log, "log", server.Log, "write HTTP requests in the combined log format to the specified `filename` (use \"-\" for logging to stdout)")
 	flags.Int64Var(&server.MaxRepoSize, "max-size", server.MaxRepoSize, "the maximum size of the repository in bytes")
 	flags.StringVar(&server.Path, "path", server.Path, "data directory")
 	flags.BoolVar(&server.TLS, "tls", server.TLS, "turn on TLS support")

--- a/mux.go
+++ b/mux.go
@@ -2,6 +2,7 @@ package restserver
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -21,9 +22,16 @@ func (s *Server) debugHandler(next http.Handler) http.Handler {
 }
 
 func (s *Server) logHandler(next http.Handler) http.Handler {
-	accessLog, err := os.OpenFile(s.Log, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-	if err != nil {
-		log.Fatalf("error: %v", err)
+	var accessLog io.Writer
+
+	if s.Log == "-" {
+		accessLog = os.Stdout
+	} else {
+		var err error
+		accessLog, err = os.OpenFile(s.Log, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		if err != nil {
+			log.Fatalf("error: %v", err)
+		}
 	}
 
 	return handlers.CombinedLoggingHandler(accessLog, next)


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

The --log option accepts "stdout", "stderr" as filenames. This prevents rest-server from opening these files, it simply writes the logs to the STDOUT or STDERR stream provided by the caller.

**BREAKING** in case the user really used "stdout", "stderr" to specify file names, you'll need to update your rest-server invocation to use "./stdout", "./stderr".


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.


Checklist
---------

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
      Not in the manual, but in the options help
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [x] I'm done, this Pull Request is ready for review
