### PR TITLE
Fix docker container setup for goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -102,6 +102,7 @@ dockers:
       - restic/rest-server:{{ .Version }}
     build_flag_templates:
       - "--pull"
+    dockerfile: "Dockerfile.goreleaser"
     extra_files:
       - docker/create_user
       - docker/delete_user

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,16 @@
+FROM alpine
+
+ENV DATA_DIRECTORY /data
+ENV PASSWORD_FILE /data/.htpasswd
+
+RUN apk add --no-cache --update apache2-utils
+
+COPY docker/create_user /usr/bin/
+COPY docker/delete_user /usr/bin/
+COPY docker/entrypoint.sh /entrypoint.sh
+COPY rest-server /usr/bin
+
+VOLUME /data
+EXPOSE 8000
+
+CMD [ "/entrypoint.sh" ]


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
The expected approach is that the binary built by goreleaser is added to the docker container.

<!--
Describe the changes here, as detailed as needed.
-->


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
The container on the docker hub is not yet version 0.12.0
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, write "Closes #1234" such
that the issue is closed automatically when this PR is merged.
-->


Checklist
---------

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [x] I'm done, this Pull Request is ready for review
