### PR TITLE
Fix inverted condition for fsync warning

### DIFF
--- a/changelog/unreleased/issue-230
+++ b/changelog/unreleased/issue-230
@@ -1,0 +1,9 @@
+Bugfix: Fix erroneous warnings about unsupported fsync
+
+Due to a regression in rest-server 0.12.0, it continuously printed
+`WARNING: fsync is not supported by the data storage. This can lead to data loss,
+if the system crashes or the storage is unexpectedly disconnected.` for systems
+that support fsync. We have fixed the warning.
+
+https://github.com/restic/rest-server/issues/230
+https://github.com/restic/rest-server/pull/231

--- a/handlers.go
+++ b/handlers.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/restic/rest-server/quota"
 	"github.com/restic/rest-server/repo"
@@ -34,6 +35,7 @@ type Server struct {
 
 	htpasswdFile *HtpasswdFile
 	quotaManager *quota.Manager
+	fsyncWarning sync.Once
 }
 
 // MaxFolderDepth is the maxDepth param passed to splitURLPath.
@@ -91,6 +93,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		QuotaManager:   s.quotaManager, // may be nil
 		PanicOnError:   s.PanicOnError,
 		NoVerifyUpload: s.NoVerifyUpload,
+		FsyncWarning:   &s.fsyncWarning,
 	}
 	if s.Prometheus {
 		opt.BlobMetricFunc = makeBlobMetricFunc(username, folderPath)

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -39,6 +39,7 @@ type Options struct {
 
 	BlobMetricFunc BlobMetricFunc
 	QuotaManager   *quota.Manager
+	FsyncWarning   *sync.Once
 }
 
 // DefaultDirMode is the file mode used for directory creation if not
@@ -74,8 +75,6 @@ func New(path string, opt Options) (*Handler, error) {
 type Handler struct {
 	path string // filesystem path of repo
 	opt  Options
-
-	fsyncWarning sync.Once
 }
 
 // httpDefaultError write a HTTP error with the default description
@@ -639,7 +638,7 @@ func (h *Handler) saveBlob(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if syncNotSup {
-		h.fsyncWarning.Do(func() {
+		h.opt.FsyncWarning.Do(func() {
 			log.Print("WARNING: fsync is not supported by the data storage. This can lead to data loss, if the system crashes or the storage is unexpectedly disconnected.")
 		})
 	} else {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rest-server!

Please note that each PR should be preceded by an issue where the suggested
change can be discussed in general and without focus on specific code. That
way, work done in the PR will better match what's been agreed in the issue.

Please fill out the following questions to make it easier for us to review
your changes. You don't have to check all the checkboxes at once, instead
feel free to add more commits over time.
-->


What is the purpose of this change? What does it change?
--------------------------------------------------------
The warning should only be printed if fsync is _not_ supported and not the other way around.

TODO:
- [x] Investigate why the warning was printed multiple times.
<!--
Describe the changes here, as detailed as needed.
-->


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes #230
Regressed in #199
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, write "Closes #1234" such
that the issue is closed automatically when this PR is merged.
-->


Checklist
---------

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [x] I'm done, this Pull Request is ready for review
