### PR TITLE
Improve security of systemd service rest-server.service by restricting network access

### DIFF
--- a/examples/systemd/rest-server.service
+++ b/examples/systemd/rest-server.service
@@ -2,9 +2,8 @@
 Description=Rest Server
 After=syslog.target
 After=network.target
-
-# if you want to use socket activation, make sure to require the socket here
-#Requires=rest-server.socket
+Requires=rest-server.socket
+After=rest-server.socket
 
 [Service]
 Type=simple
@@ -37,6 +36,11 @@ CapabilityBoundingSet=
 LockPersonality=true
 MemoryDenyWriteExecute=true
 NoNewPrivileges=yes
+
+# As the listen socket is created by systemd via the rest-server.socket unit, it is
+# no longer necessary for rest-server to have access to the host network namespace.
+PrivateNetwork=yes
+
 PrivateTmp=yes
 PrivateDevices=true
 PrivateUsers=true
@@ -51,7 +55,7 @@ ProtectProc=invisible
 ProtectHostname=true
 RemoveIPC=true
 RestrictNamespaces=true
-RestrictAddressFamilies=AF_INET AF_INET6
+RestrictAddressFamilies=none
 RestrictSUIDSGID=true
 RestrictRealtime=true
 # if your service crashes with "code=killed, status=31/SYS", you probably tried to run linux_i386 (32bit) binary on a amd64 host


### PR DESCRIPTION


<!--
Thank you very much for contributing code or documentation to rest-server!

Please note that each PR should be preceded by an issue where the suggested
change can be discussed in general and without focus on specific code. That
way, work done in the PR will better match what's been agreed in the issue.

Please fill out the following questions to make it easier for us to review
your changes. You don't have to check all the checkboxes at once, instead
feel free to add more commits over time.
-->


What is the purpose of this change? What does it change?
--------------------------------------------------------

Improve security of rest-server.service by restricting network access.


This patch improves the overall security assessment score given by `systemd-analyze security rest-server.service` from "1.3 OK" to "0.6 SAFE" (when using systemd-analyze version 253)



* Remove `AF_INET AF_INET6` from RestrictAddressFamilies. Sockets originating from socket activation are not affected by the systemd directive RestrictAddressFamilies. See [systemd.exec](https://www.freedesktop.org/software/systemd/man/systemd.exec.html) man page.

* Add `PrivateNetwork=yes` as recommended for socket-activated services in the [systemd.socket](https://www.freedesktop.org/software/systemd/man/systemd.socket.html) man page.

* Add dependency on rest-server.socket

<!--
Describe the changes here, as detailed as needed.
-->




Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Yes, in the forum:

https://forum.restic.net/t/using-none-instead-of-af-inet-af-inet6-for-restrictaddressfamilies-in-systemd-unit-rest-server-service/6448

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, write "Closes #1234" such
that the issue is closed automatically when this PR is merged.
-->


Checklist
---------

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [x] I'm done, this Pull Request is ready for review
