### PR TITLE
Add /healthz endpoint to server

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -98,6 +98,9 @@ func NewHandler(server *Server) (http.Handler, error) {
 			mux.HandleFunc("/metrics", server.wrapMetricsAuth(promhttp.Handler().ServeHTTP))
 		}
 	}
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
 	mux.Handle("/", server)
 
 	var handler http.Handler = mux


### PR DESCRIPTION
This PR adds a tiny handler for `/healthz`, which responds with an empty response and 204 status code. This is very helpful to set up healthchecks (for example, liveness probes), in a container orchestrator or proxy.

I saw that 2 years ago, someone started working on health endpoints in #159, but that PR seems to have been abandoned.

This PR is a lot simpler in the approach as it always responds with a 204 status code, without performing any actual check: it just asserts that rest-server is running and healthy.