### PR TITLE
Update rest-server.socket with correct default rest-server port

### DIFF
--- a/examples/systemd/rest-server.socket
+++ b/examples/systemd/rest-server.socket
@@ -1,5 +1,5 @@
 [Socket]
-ListenStream = 8080
+ListenStream = 8000
 
 [Install]
 WantedBy = sockets.target


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Change the example rest-server.socket file to match the default port used by rest-server


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Discussed, not really, but I've created #269

Checklist
---------

- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [X] I have run `gofmt` on the code in all commits
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [ ] I'm done, this Pull Request is ready for review

Will add a changelog file and check that the commit message matches the other commits if the changes are fine to be accepted