### PR TITLE
Enhancement: add support for unix socket listen

### DIFF
--- a/changelog/unreleased/pull-272
+++ b/changelog/unreleased/pull-272
@@ -1,12 +1,12 @@
-Enhancement: can now listen on a unix socket
+Enhancement: Support listening on a unix socket
 
-If `--listen unix:/tmp/foo` is passed, the server will listen on a unix socket. This is triggered by the prefix `unix:`.
+To let rest-server listen on a unix socket, prefix the socket filename with `unix:` and pass it to the `--listen` option, for example `--listen unix:/tmp/foo`.
 
-This is useful in combination with remote port portforwarding to enable remote server to backup locally, e.g.
+This is useful in combination with remote port forwarding to enable remote server to backup locally, e.g.
 
-```bash
+```
 rest-server --listen unix:/tmp/foo &
-ssh -R /tmp/foo:/tmp/foo user@host restic -r rest:http+unix:/tmp/foo:/repo backup
+ssh -R /tmp/foo:/tmp/foo user@host restic -r rest:http+unix:///tmp/foo:/repo backup
 ```
 
 https://github.com/restic/rest-server/pull/272

--- a/changelog/unreleased/pull-272
+++ b/changelog/unreleased/pull-272
@@ -1,0 +1,12 @@
+Enhancement: can now listen on a unix socket
+
+If `--listen unix:/tmp/foo` is passed, the server will listen on a unix socket. This is triggered by the prefix `unix:`.
+
+This is useful in combination with remote port portforwarding to enable remote server to backup locally, e.g.
+
+```bash
+rest-server --listen unix:/tmp/foo &
+ssh -R /tmp/foo:/tmp/foo user@host restic -r rest:http+unix:/tmp/foo:/repo backup
+```
+
+https://github.com/restic/rest-server/pull/272

--- a/cmd/rest-server/listener_unix_test.go
+++ b/cmd/rest-server/listener_unix_test.go
@@ -1,0 +1,75 @@
+//go:build !windows
+// +build !windows
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestUnixSocket(t *testing.T) {
+	td := t.TempDir()
+
+	// this is the socket we'll listen on and connect to
+	tempSocket := filepath.Join(td, "sock")
+
+	// create some content and parent dirs
+	if err := os.MkdirAll(filepath.Join(td, "data", "repo1"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(td, "data", "repo1", "config"), []byte("foo"), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	// run the following twice, to test that the server will
+	// cleanup its socket file when quitting, which won't happen
+	// if it doesn't exit gracefully
+	for i := 0; i < 2; i++ {
+		err := testServerWithArgs([]string{
+			"--no-auth",
+			"--path", filepath.Join(td, "data"),
+			"--listen", fmt.Sprintf("unix:%s", tempSocket),
+		}, time.Second, func(ctx context.Context, _ *restServerApp) error {
+			// custom client that will talk HTTP to unix socket
+			client := http.Client{
+				Transport: &http.Transport{
+					DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+						return net.Dial("unix", tempSocket)
+					},
+				},
+			}
+			for _, test := range []struct {
+				Path       string
+				StatusCode int
+			}{
+				{"/repo1/", http.StatusMethodNotAllowed},
+				{"/repo1/config", http.StatusOK},
+				{"/repo2/config", http.StatusNotFound},
+			} {
+				req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://ignored"+test.Path, nil)
+				if err != nil {
+					return err
+				}
+				resp, err := client.Do(req)
+				if err != nil {
+					return err
+				}
+				resp.Body.Close()
+				if resp.StatusCode != test.StatusCode {
+					return fmt.Errorf("expected %d from server, instead got %d (path %s)", test.StatusCode, resp.StatusCode, test.Path)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
Enhancement: add support for unix socket listen

Refactor main for easier testing, graceful termination and be able to prin the listening port after startup.

Add tests for both TCP and Unix socket listening.

The change to add unix socket listening was pretty simple, but the PR got bit bigger then I made some refactors to `main.go` to make it easier for testing (by removing use of gloabl variables).

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Yes. This is the `rest-server` part of https://github.com/restic/restic/issues/4287

(it also includes the tiny change I proposed in #271)

Checklist
---------

- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [X] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [X] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [X] I'm done, this Pull Request is ready for review
