### PR TITLE
Output status of append only mode on startup

### DIFF
--- a/changelog/unreleased/pull-295
+++ b/changelog/unreleased/pull-295
@@ -1,0 +1,5 @@
+Enhancement: Output status of append only mode on startup
+
+Rest-server now outputs whether append only mode has been enabled on startup.
+
+https://github.com/restic/rest-server/pull/295

--- a/cmd/rest-server/main.go
+++ b/cmd/rest-server/main.go
@@ -135,6 +135,12 @@ func (app *restServerApp) runRoot(cmd *cobra.Command, args []string) error {
 		log.Fatalf("error: %v", err)
 	}
 
+	if app.Server.AppendOnly {
+		log.Println("Append only mode enabled")
+	} else {
+		log.Println("Append only mode disabled")
+	}
+
 	if app.Server.PrivateRepos {
 		log.Println("Private repositories enabled")
 	} else {


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Previously, rest-server did not output whether append only mode
was enabled or disabled when starting up. The status of private
repositories was however output.

Since private repositories and append only are two important
settings that are directly related to the security of the rest-server
instance, it seems prudent to also output the status of append only.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No, I was just missing it in the output when setting up a new rest-server
instance in append-only mode.

Checklist
---------

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [x] I'm done, this Pull Request is ready for review