### PR TITLE
Add support for proxy-based authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,16 @@ docker exec -it rest_server create_user myuser mypassword
 docker exec -it rest_server delete_user myuser
 ```
 
+## Proxy Authentication
+
+See above for no authentication (`--no-auth`) and basic authentication.
+
+To delegate authentication to a proxy, use the `--proxy-auth-username` flag. The specified header name, for example `X-Forwarded-User`,
+must be present in the request headers and specifies the username. Basic authentication is disabled when this flag is set.
+
+Warning: rest-server trusts the username in the header. It is the responsibility of the proxy
+to ensure that the username is correct and cannot be forged by an attacker.
+
 
 ## Prometheus support and Grafana dashboard
 

--- a/changelog/unreleased/pull-307
+++ b/changelog/unreleased/pull-307
@@ -1,0 +1,8 @@
+Enhancement: Add support for proxy-based authentication
+
+The server now supports authentication via a proxy header specified with the --proxy-auth flag (e.g., --proxy-auth=X-Forwarded-User).
+When this flag is set, the server will authenticate users based on the given header and disable BasicAuth.
+Note that --proxy-auth is ignored if --no-auth is set, as --no-auth disables all authentication.
+
+https://github.com/restic/rest-server/issues/174
+https://github.com/restic/rest-server/pull/307

--- a/changelog/unreleased/pull-307
+++ b/changelog/unreleased/pull-307
@@ -1,8 +1,8 @@
 Enhancement: Add support for proxy-based authentication
 
-The server now supports authentication via a proxy header specified with the --proxy-auth flag (e.g., --proxy-auth=X-Forwarded-User).
+The server now supports authentication via a proxy header specified with the `--proxy-auth-username` flag (e.g., `--proxy-auth-username=X-Forwarded-User`).
 When this flag is set, the server will authenticate users based on the given header and disable BasicAuth.
-Note that --proxy-auth is ignored if --no-auth is set, as --no-auth disables all authentication.
+Note that `--proxy-auth-username` is ignored if `--no-auth` is set, as `--no-auth` disables all authentication.
 
 https://github.com/restic/rest-server/issues/174
 https://github.com/restic/rest-server/pull/307

--- a/cmd/rest-server/main.go
+++ b/cmd/rest-server/main.go
@@ -61,8 +61,9 @@ func newRestServerApp() *restServerApp {
 	flags.BoolVar(&rv.Server.TLS, "tls", rv.Server.TLS, "turn on TLS support")
 	flags.StringVar(&rv.Server.TLSCert, "tls-cert", rv.Server.TLSCert, "TLS certificate path")
 	flags.StringVar(&rv.Server.TLSKey, "tls-key", rv.Server.TLSKey, "TLS key path")
-	flags.BoolVar(&rv.Server.NoAuth, "no-auth", rv.Server.NoAuth, "disable .htpasswd authentication")
+	flags.BoolVar(&rv.Server.NoAuth, "no-auth", rv.Server.NoAuth, "disable authentication")
 	flags.StringVar(&rv.Server.HtpasswdPath, "htpasswd-file", rv.Server.HtpasswdPath, "location of .htpasswd file (default: \"<data directory>/.htpasswd)\"")
+	flags.StringVar(&rv.Server.ProxyAuthUsername, "proxy-auth-username", rv.Server.ProxyAuthUsername, "specifies the HTTP header containing the username for proxy-based authentication")
 	flags.BoolVar(&rv.Server.NoVerifyUpload, "no-verify-upload", rv.Server.NoVerifyUpload,
 		"do not verify the integrity of uploaded data. DO NOT enable unless the rest-server runs on a very low-power device")
 	flags.BoolVar(&rv.Server.AppendOnly, "append-only", rv.Server.AppendOnly, "enable append only mode")
@@ -130,7 +131,11 @@ func (app *restServerApp) runRoot(_ *cobra.Command, _ []string) error {
 	if app.Server.NoAuth {
 		log.Println("Authentication disabled")
 	} else {
-		log.Println("Authentication enabled")
+		if app.Server.ProxyAuthUsername == "" {
+			log.Println("Authentication enabled")
+		} else {
+			log.Println("Proxy Authentication enabled.")
+		}
 	}
 
 	handler, err := restserver.NewHandler(&app.Server)

--- a/cmd/rest-server/main_test.go
+++ b/cmd/rest-server/main_test.go
@@ -118,6 +118,12 @@ func TestGetHandler(t *testing.T) {
 		t.Errorf("NoAuth=true: expected no error, got %v", err)
 	}
 
+	// With NoAuth = false, no .htpasswd and ProxyAuth = X-Remote-User
+	_, err = getHandler(&restserver.Server{Path: dir, ProxyAuthUsername: "X-Remote-User"})
+	if err != nil {
+		t.Errorf("NoAuth=false, ProxyAuthUsername = X-Remote-User: expected no error, got %v", err)
+	}
+
 	// With NoAuth = false and custom .htpasswd
 	htpFile, err := os.CreateTemp(dir, "custom")
 	if err != nil {

--- a/handlers.go
+++ b/handlers.go
@@ -24,6 +24,7 @@ type Server struct {
 	TLSCert              string
 	TLS                  bool
 	NoAuth               bool
+	ProxyAuthUsername    string
 	AppendOnly           bool
 	PrivateRepos         bool
 	Prometheus           bool

--- a/mux_test.go
+++ b/mux_test.go
@@ -51,6 +51,14 @@ func TestCheckAuth(t *testing.T) {
 			},
 			expectedOk: false,
 		},
+		{
+			name:   "Proxy Auth send but not enabled",
+			server: &Server{},
+			requestHeaders: map[string]string{
+				"X-Remote-User": "restic",
+			},
+			expectedOk: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/mux_test.go
+++ b/mux_test.go
@@ -1,0 +1,72 @@
+package restserver
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCheckAuth(t *testing.T) {
+	tests := []struct {
+		name           string
+		server         *Server
+		requestHeaders map[string]string
+		basicAuth      bool
+		basicUser      string
+		basicPassword  string
+		expectedUser   string
+		expectedOk     bool
+	}{
+		{
+			name: "NoAuth enabled",
+			server: &Server{
+				NoAuth: true,
+			},
+			expectedOk: true,
+		},
+		{
+			name: "Proxy Auth successful",
+			server: &Server{
+				ProxyAuthUsername: "X-Remote-User",
+			},
+			requestHeaders: map[string]string{
+				"X-Remote-User": "restic",
+			},
+			expectedUser: "restic",
+			expectedOk:   true,
+		},
+		{
+			name: "Proxy Auth empty header",
+			server: &Server{
+				ProxyAuthUsername: "X-Remote-User",
+			},
+			requestHeaders: map[string]string{
+				"X-Remote-User": "",
+			},
+			expectedOk: false,
+		},
+		{
+			name: "Proxy Auth missing header",
+			server: &Server{
+				ProxyAuthUsername: "X-Remote-User",
+			},
+			expectedOk: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", nil)
+			for header, value := range tt.requestHeaders {
+				req.Header.Set(header, value)
+			}
+			if tt.basicAuth {
+				req.SetBasicAuth(tt.basicUser, tt.basicPassword)
+			}
+
+			username, ok := tt.server.checkAuth(req)
+			if username != tt.expectedUser || ok != tt.expectedOk {
+				t.Errorf("expected (%v, %v), got (%v, %v)", tt.expectedUser, tt.expectedOk, username, ok)
+			}
+		})
+	}
+}


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

This change adds support for reverse-proxy-based authentication with private repositories.

It introduces the `--proxy-auth-username` flag, which allows users to specify the header name containing the username so that the server can handle the access on the specific repository.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

In #174 it was discussed that proxy-based authentication in combination with private repositories requires a header containing the username. For maximum compatibility, the name of this header should be configurable.

Checklist
---------

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [ ] I'm done, this Pull Request is ready for review
