### PR TITLE
Hardened tls cipher suits and added option for tls min version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,25 +32,27 @@ Usage:
   rest-server [flags]
 
 Flags:
-      --append-only            enable append only mode
-      --cpu-profile string     write CPU profile to file
-      --debug                  output debug messages
-  -h, --help                   help for rest-server
-      --htpasswd-file string   location of .htpasswd file (default: "<data directory>/.htpasswd")
-      --listen string          listen address (default ":8000")
-      --log filename           write HTTP requests in the combined log format to the specified filename
-      --max-size int           the maximum size of the repository in bytes
-      --no-auth                disable .htpasswd authentication
-      --no-verify-upload       do not verify the integrity of uploaded data. DO NOT enable unless the rest-server runs on a very low-power device
-      --path string            data directory (default "/tmp/restic")
-      --private-repos          users can only access their private repo
-      --prometheus             enable Prometheus metrics
-      --prometheus-no-auth     disable auth for Prometheus /metrics endpoint
-      --tls                    turn on TLS support
-      --tls-cert string        TLS certificate path
-      --tls-key string         TLS key path
-      --tls-min-ver string     TLS min version (1.2|1.3, default: 1.2)
-  -v, --version                version for rest-server
+      --append-only                  enable append only mode
+      --cpu-profile string           write CPU profile to file
+      --debug                        output debug messages
+      --group-accessible-repos       let filesystem group be able to access repo files
+  -h, --help                         help for rest-server
+      --htpasswd-file string         location of .htpasswd file (default: "<data directory>/.htpasswd)"
+      --listen string                listen address (default ":8000")
+      --log filename                 write HTTP requests in the combined log format to the specified filename (use "-" for logging to stdout)
+      --max-size int                 the maximum size of the repository in bytes
+      --no-auth                      disable .htpasswd authentication
+      --no-verify-upload             do not verify the integrity of uploaded data. DO NOT enable unless the rest-server runs on a very low-power device
+      --path string                  data directory (default "/tmp/restic")
+      --private-repos                users can only access their private repo
+      --prometheus                   enable Prometheus metrics
+      --prometheus-no-auth           disable auth for Prometheus /metrics endpoint
+      --proxy-auth-username string   specifies the HTTP header containing the username for proxy-based authentication
+      --tls                          turn on TLS support
+      --tls-cert string              TLS certificate path
+      --tls-key string               TLS key path
+      --tls-min-ver string           TLS min version, one of (1.2|1.3) (default "1.2")
+  -v, --version                      version for rest-server
 ```
 
 By default the server persists backup data in the OS temporary directory (`/tmp/restic` on Linux/BSD and others, in `%TEMP%\\restic` in Windows, etc). **If `rest-server` is launched using the default path, all backups will be lost**. To start the server with a custom persistence directory and with authentication disabled:
@@ -69,7 +71,7 @@ If you want to disable authentication, you must add the `--no-auth` flag. If thi
 
 NOTE: In older versions of rest-server (up to 0.9.7), this flag does not exist and the server disables authentication if `.htpasswd` is missing or cannot be opened.
 
-By default the server uses HTTP protocol.  This is not very secure since with Basic Authentication, user name and passwords will be sent in clear text in every request.  In order to enable TLS support just add the `--tls` argument and add a private and public key at the root of your persistence directory. You may also specify private and public keys by `--tls-cert` and `--tls-key` and set the minimum TLS version by `--tls-min-ver [1.2|1.3]`.
+By default the server uses HTTP protocol.  This is not very secure since with Basic Authentication, user name and passwords will be sent in clear text in every request.  In order to enable TLS support just add the `--tls` argument and add a private and public key at the root of your persistence directory. You may also specify private and public keys by `--tls-cert` and `--tls-key` and set the minimum TLS version to 1.3 using `--tls-min-ver 1.3`.
 
 Signed certificate is normally required by the restic backend, but if you just want to test the feature you can generate password-less unsigned keys with the following command:
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Flags:
       --tls                    turn on TLS support
       --tls-cert string        TLS certificate path
       --tls-key string         TLS key path
-      --tls-min-ver string     TLS min version (default: 1.2) (default "1.2")
+      --tls-min-ver string     TLS min version (default: 1.2)
   -v, --version                version for rest-server
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Flags:
       --tls                    turn on TLS support
       --tls-cert string        TLS certificate path
       --tls-key string         TLS key path
+      --tls-min-ver string     TLS min version (default: 1.2) (default "1.2")
   -v, --version                version for rest-server
 ```
 
@@ -68,7 +69,7 @@ If you want to disable authentication, you must add the `--no-auth` flag. If thi
 
 NOTE: In older versions of rest-server (up to 0.9.7), this flag does not exist and the server disables authentication if `.htpasswd` is missing or cannot be opened.
 
-By default the server uses HTTP protocol.  This is not very secure since with Basic Authentication, user name and passwords will be sent in clear text in every request.  In order to enable TLS support just add the `--tls` argument and add a private and public key at the root of your persistence directory. You may also specify private and public keys by `--tls-cert` and `--tls-key`.
+By default the server uses HTTP protocol.  This is not very secure since with Basic Authentication, user name and passwords will be sent in clear text in every request.  In order to enable TLS support just add the `--tls` argument and add a private and public key at the root of your persistence directory. You may also specify private and public keys by `--tls-cert` and `--tls-key` and set the minimum TLS version by `--tls-min-ver`.
 
 Signed certificate is normally required by the restic backend, but if you just want to test the feature you can generate password-less unsigned keys with the following command:
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Flags:
       --tls                    turn on TLS support
       --tls-cert string        TLS certificate path
       --tls-key string         TLS key path
-      --tls-min-ver string     TLS min version (default: 1.2)
+      --tls-min-ver string     TLS min version (1.2|1.3, default: 1.2)
   -v, --version                version for rest-server
 ```
 
@@ -69,7 +69,7 @@ If you want to disable authentication, you must add the `--no-auth` flag. If thi
 
 NOTE: In older versions of rest-server (up to 0.9.7), this flag does not exist and the server disables authentication if `.htpasswd` is missing or cannot be opened.
 
-By default the server uses HTTP protocol.  This is not very secure since with Basic Authentication, user name and passwords will be sent in clear text in every request.  In order to enable TLS support just add the `--tls` argument and add a private and public key at the root of your persistence directory. You may also specify private and public keys by `--tls-cert` and `--tls-key` and set the minimum TLS version by `--tls-min-ver`.
+By default the server uses HTTP protocol.  This is not very secure since with Basic Authentication, user name and passwords will be sent in clear text in every request.  In order to enable TLS support just add the `--tls` argument and add a private and public key at the root of your persistence directory. You may also specify private and public keys by `--tls-cert` and `--tls-key` and set the minimum TLS version by `--tls-min-ver [1.2|1.3]`.
 
 Signed certificate is normally required by the restic backend, but if you just want to test the feature you can generate password-less unsigned keys with the following command:
 

--- a/changelog/unreleased/pull-315
+++ b/changelog/unreleased/pull-315
@@ -1,0 +1,6 @@
+Enhancement: Hardened tls settings
+
+rest-server now uses a secure tls cipher suit set and the minimal TLS version
+can be set with the option `--tls-min-ver`
+
+https://github.com/restic/rest-server/pull/315

--- a/cmd/rest-server/main.go
+++ b/cmd/rest-server/main.go
@@ -63,7 +63,7 @@ func newRestServerApp() *restServerApp {
 	flags.BoolVar(&rv.Server.TLS, "tls", rv.Server.TLS, "turn on TLS support")
 	flags.StringVar(&rv.Server.TLSCert, "tls-cert", rv.Server.TLSCert, "TLS certificate path")
 	flags.StringVar(&rv.Server.TLSKey, "tls-key", rv.Server.TLSKey, "TLS key path")
-	flags.StringVar(&rv.Server.TLSMinVer, "tls-min-ver", rv.Server.TLSMinVer, "TLS min version [1.2|1.3]")
+	flags.StringVar(&rv.Server.TLSMinVer, "tls-min-ver", rv.Server.TLSMinVer, "TLS min version, one of (1.2|1.3)")
 	flags.BoolVar(&rv.Server.NoAuth, "no-auth", rv.Server.NoAuth, "disable authentication")
 	flags.StringVar(&rv.Server.HtpasswdPath, "htpasswd-file", rv.Server.HtpasswdPath, "location of .htpasswd file (default: \"<data directory>/.htpasswd)\"")
 	flags.StringVar(&rv.Server.ProxyAuthUsername, "proxy-auth-username", rv.Server.ProxyAuthUsername, "specifies the HTTP header containing the username for proxy-based authentication")

--- a/cmd/rest-server/main.go
+++ b/cmd/rest-server/main.go
@@ -63,7 +63,7 @@ func newRestServerApp() *restServerApp {
 	flags.BoolVar(&rv.Server.TLS, "tls", rv.Server.TLS, "turn on TLS support")
 	flags.StringVar(&rv.Server.TLSCert, "tls-cert", rv.Server.TLSCert, "TLS certificate path")
 	flags.StringVar(&rv.Server.TLSKey, "tls-key", rv.Server.TLSKey, "TLS key path")
-	flags.StringVar(&rv.Server.TLSMinVer, "tls-min-ver", rv.Server.TLSMinVer, "TLS min version (default: 1.2)")
+	flags.StringVar(&rv.Server.TLSMinVer, "tls-min-ver", rv.Server.TLSMinVer, "TLS min version [1.2|1.3]")
 	flags.BoolVar(&rv.Server.NoAuth, "no-auth", rv.Server.NoAuth, "disable authentication")
 	flags.StringVar(&rv.Server.HtpasswdPath, "htpasswd-file", rv.Server.HtpasswdPath, "location of .htpasswd file (default: \"<data directory>/.htpasswd)\"")
 	flags.StringVar(&rv.Server.ProxyAuthUsername, "proxy-auth-username", rv.Server.ProxyAuthUsername, "specifies the HTTP header containing the username for proxy-based authentication")
@@ -180,7 +180,7 @@ func (app *restServerApp) runRoot(_ *cobra.Command, _ []string) error {
 	app.listenerAddressMu.Unlock()
 
 	tlscfg := &tls.Config{
-		MinVersion:       tls.VersionTLS12,
+		MinVersion: tls.VersionTLS12,
 		CipherSuites: []uint16{
 			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,

--- a/cmd/rest-server/main.go
+++ b/cmd/rest-server/main.go
@@ -181,7 +181,6 @@ func (app *restServerApp) runRoot(_ *cobra.Command, _ []string) error {
 
 	tlscfg := &tls.Config{
 		MinVersion:       tls.VersionTLS12,
-		CurvePreferences: []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
 		CipherSuites: []uint16{
 			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
@@ -192,18 +191,12 @@ func (app *restServerApp) runRoot(_ *cobra.Command, _ []string) error {
 		},
 	}
 	switch app.Server.TLSMinVer {
-	case "1.0":
-		// Only available with GODEBUG="tls10server=1"
-		tlscfg.MinVersion = tls.VersionTLS10
-	case "1.1":
-		// Only available with GODEBUG="tls10server=1"
-		tlscfg.MinVersion = tls.VersionTLS11
 	case "1.2":
 		tlscfg.MinVersion = tls.VersionTLS12
 	case "1.3":
 		tlscfg.MinVersion = tls.VersionTLS13
 	default:
-		tlscfg.MinVersion = tls.VersionTLS12
+		return fmt.Errorf("Unsupported TLS min version: %s", app.Server.TLSMinVer)
 	}
 
 	srv := &http.Server{

--- a/cmd/rest-server/main.go
+++ b/cmd/rest-server/main.go
@@ -196,7 +196,7 @@ func (app *restServerApp) runRoot(_ *cobra.Command, _ []string) error {
 	case "1.3":
 		tlscfg.MinVersion = tls.VersionTLS13
 	default:
-		return fmt.Errorf("Unsupported TLS min version: %s", app.Server.TLSMinVer)
+		return fmt.Errorf("Unsupported TLS min version: %s. Allowed versions are 1.2 or 1.3", app.Server.TLSMinVer)
 	}
 
 	srv := &http.Server{

--- a/cmd/rest-server/main.go
+++ b/cmd/rest-server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"log"
@@ -45,8 +46,9 @@ func newRestServerApp() *restServerApp {
 			Version: fmt.Sprintf("rest-server %s compiled with %v on %v/%v\n", version, runtime.Version(), runtime.GOOS, runtime.GOARCH),
 		},
 		Server: restserver.Server{
-			Path:   filepath.Join(os.TempDir(), "restic"),
-			Listen: ":8000",
+			Path:      filepath.Join(os.TempDir(), "restic"),
+			Listen:    ":8000",
+			TLSMinVer: "1.2",
 		},
 	}
 	rv.CmdRoot.RunE = rv.runRoot
@@ -61,6 +63,7 @@ func newRestServerApp() *restServerApp {
 	flags.BoolVar(&rv.Server.TLS, "tls", rv.Server.TLS, "turn on TLS support")
 	flags.StringVar(&rv.Server.TLSCert, "tls-cert", rv.Server.TLSCert, "TLS certificate path")
 	flags.StringVar(&rv.Server.TLSKey, "tls-key", rv.Server.TLSKey, "TLS key path")
+	flags.StringVar(&rv.Server.TLSMinVer, "tls-min-ver", rv.Server.TLSMinVer, "TLS min version (default: 1.2)")
 	flags.BoolVar(&rv.Server.NoAuth, "no-auth", rv.Server.NoAuth, "disable authentication")
 	flags.StringVar(&rv.Server.HtpasswdPath, "htpasswd-file", rv.Server.HtpasswdPath, "location of .htpasswd file (default: \"<data directory>/.htpasswd)\"")
 	flags.StringVar(&rv.Server.ProxyAuthUsername, "proxy-auth-username", rv.Server.ProxyAuthUsername, "specifies the HTTP header containing the username for proxy-based authentication")
@@ -176,8 +179,36 @@ func (app *restServerApp) runRoot(_ *cobra.Command, _ []string) error {
 	app.listenerAddress = listener.Addr()
 	app.listenerAddressMu.Unlock()
 
+	tlscfg := &tls.Config{
+		MinVersion:       tls.VersionTLS12,
+		CurvePreferences: []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+		},
+	}
+	switch app.Server.TLSMinVer {
+	case "1.0":
+		// Only available with GODEBUG="tls10server=1"
+		tlscfg.MinVersion = tls.VersionTLS10
+	case "1.1":
+		// Only available with GODEBUG="tls10server=1"
+		tlscfg.MinVersion = tls.VersionTLS11
+	case "1.2":
+		tlscfg.MinVersion = tls.VersionTLS12
+	case "1.3":
+		tlscfg.MinVersion = tls.VersionTLS13
+	default:
+		tlscfg.MinVersion = tls.VersionTLS12
+	}
+
 	srv := &http.Server{
-		Handler: handler,
+		Handler:   handler,
+		TLSConfig: tlscfg,
 	}
 
 	// run server in background

--- a/handlers.go
+++ b/handlers.go
@@ -22,6 +22,7 @@ type Server struct {
 	CPUProfile           string
 	TLSKey               string
 	TLSCert              string
+	TLSMinVer            string
 	TLS                  bool
 	NoAuth               bool
 	ProxyAuthUsername    string


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

With tls activated, the rest-server will provide insecure tls versions and insecure or broken tls cipher suits. This change configures the default settings in tls mode, sets a secure set of cipher suits (according to CIS NGINX Benchmark v2.1.0) and sets up TLSv1.2 as min version. It also adds a command line parameter to select a different version as min version.

The current version of the crypto.tls library also sets a small, secure set of cipher suits as default and limits the available TLS versions to 1.2 and 1.3. Earlier versions are also available but have to be explicitly enabled during compilation.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #251 


Checklist
---------

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [x] I'm done, this Pull Request is ready for review
