### PR TITLE
Support passwords with spaces in docker container

### DIFF
--- a/docker/create_user
+++ b/docker/create_user
@@ -9,8 +9,8 @@ fi
 
 if [ -z "$2" ]; then
     # password from prompt
-    htpasswd -B $PASSWORD_FILE $1
+    htpasswd -B "$PASSWORD_FILE" "$1"
 else
     # read password from command line
-    htpasswd -B -b $PASSWORD_FILE $1 "$2"
+    htpasswd -B -b "$PASSWORD_FILE" "$1" "$2"
 fi

--- a/docker/create_user
+++ b/docker/create_user
@@ -12,5 +12,5 @@ if [ -z "$2" ]; then
     htpasswd -B $PASSWORD_FILE $1
 else
     # read password from command line
-    htpasswd -B -b $PASSWORD_FILE $1 $2
+    htpasswd -B -b $PASSWORD_FILE $1 "$2"
 fi

--- a/docker/delete_user
+++ b/docker/delete_user
@@ -5,4 +5,4 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-htpasswd -D $PASSWORD_FILE $1
+htpasswd -D "$PASSWORD_FILE" "$1"


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rest-server! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
create_user script does not support passwords with spaces.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
I found no Issues discussing this.

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/rest-server/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
