### PR TITLE
Bump minimum Go version to 1.23

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,18 +13,30 @@ permissions:
   contents: read
 
 env:
-  latest_go: "1.23.x"
+  latest_go: "1.24.x"
   GO111MODULE: on
 
 jobs:
   test:
     strategy:
       matrix:
-        go:
-          - 1.23.x
-          - 1.22.x
-    runs-on: ubuntu-latest
-    name: Go ${{ matrix.go }}
+        include:
+          - job_name: Linux
+            go: 1.24.x
+            os: ubuntu-latest
+            check_changelog: true
+
+          - job_name: Linux (race)
+            go: 1.24.x
+            os: ubuntu-latest
+            test_opts: "-race"
+
+          - job_name: Linux
+            go: 1.23.x
+            os: ubuntu-latest
+
+    name: ${{ matrix.job_name }} Go ${{ matrix.go }}
+    runs-on: ${{ matrix.os }}
 
     env:
       GOPROXY: https://proxy.golang.org
@@ -46,7 +58,7 @@ jobs:
 
       - name: Run local Tests
         run: |
-          go test ./...
+          go test -cover ${{matrix.test_opts}} ./...
 
       - name: Check changelog files with calens
         run: |
@@ -55,6 +67,7 @@ jobs:
 
           echo "check changelog files"
           calens
+        if: matrix.check_changelog
 
   lint:
     name: lint
@@ -76,7 +89,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.63.4
+          version: v1.64.8
           args: --verbose --timeout 5m
 
         # only run golangci-lint for pull requests, otherwise ALL hints get

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Rest Server is a high performance HTTP server that implements restic's [REST bac
 
 ## Requirements
 
-Rest Server requires Go 1.22 or higher to build.  The only tested compiler is the official Go compiler.
+Rest Server requires Go 1.23 or higher to build.  The only tested compiler is the official Go compiler.
 
 The required version of restic backup client to use with `rest-server` is [v0.7.1](https://github.com/restic/restic/releases/tag/v0.7.1) or higher.
 

--- a/build.go
+++ b/build.go
@@ -58,7 +58,7 @@ var config = Config{
 	Namespace:  "github.com/restic/rest-server",                 // subdir of GOPATH, e.g. "github.com/foo/bar"
 	Main:       "github.com/restic/rest-server/cmd/rest-server", // package name for the main package
 	Tests:      []string{"./..."},                               // tests to run
-	MinVersion: GoVersion{Major: 1, Minor: 22, Patch: 0},        // minimum Go version supported
+	MinVersion: GoVersion{Major: 1, Minor: 23, Patch: 0},        // minimum Go version supported
 }
 
 // Config configures the build.

--- a/changelog/unreleased/pull-322
+++ b/changelog/unreleased/pull-322
@@ -1,9 +1,10 @@
-Change: Update dependencies and require Go 1.22 or newer
+Change: Update dependencies and require Go 1.23 or newer
 
-We have updated all dependencies. Since some libraries require newer Go standard
-library features, support for Go 1.18 to 1.21 has been dropped, which means
-that rest-server now requires at least Go 1.22 to build.
+We have updated all dependencies. Rest-server now requires Go 1.23 or newer to build.
 
-This also disables support for TLS versions older than TLS 1.2.
+This also disables support for TLS versions older than TLS 1.2. On Windows,
+rest-server now requires at least Windows 10 or Windows Server 2016. On macOS,
+rest-server now requires at least macOS 11 Big Sur.
 
 https://github.com/restic/rest-server/pull/322
+https://github.com/restic/rest-server/pull/338

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/restic/rest-server
 
-go 1.22
+go 1.23.0
 
 require (
 	github.com/coreos/go-systemd/v22 v22.5.0


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rest-server! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Require Go 1.23 as older versions are no longer supported. The latest golang.org/x/ packages require Go 1.23.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/rest-server/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
