### PR TITLE
Limit htpasswd perms

### DIFF
--- a/changelog/unreleased/issue-318
+++ b/changelog/unreleased/issue-318
@@ -1,0 +1,13 @@
+Security: Fix world-readable permissions on new `.htpasswd` files
+
+On startup the rest-server Docker container creates an empty `.htpasswd` file
+if none exists yet. This file was world-readable by default, which can be
+a security risk, even though the file only contains hashed passwords.
+
+This has been fixed such that new `.htpasswd` files are no longer world-readabble.
+
+The permissions of existing `.htpasswd` files must be manually changed
+if relevant in your setup.
+
+https://github.com/restic/rest-server/issues/318
+https://github.com/restic/rest-server/pull/340

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,7 +6,7 @@ if [ -n "$DISABLE_AUTHENTICATION" ]; then
     OPTIONS="--no-auth $OPTIONS"
 else
     if [ ! -f "$PASSWORD_FILE" ]; then
-        touch "$PASSWORD_FILE"
+        ( umask 027 && touch "$PASSWORD_FILE" )
     fi
 
     if [ ! -s "$PASSWORD_FILE" ]; then


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rest-server! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
When rest-server is started without a htpasswd file, it creates an empty file. Make this file not world readable.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/rest-server/issues/318
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/rest-server/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE)).
- [ ] I'm done! This pull request is ready for review.
