### PR TITLE
Remove version specification from docker-compose.yml

### DIFF
--- a/examples/compose-with-grafana/docker-compose.yml
+++ b/examples/compose-with-grafana/docker-compose.yml
@@ -1,5 +1,4 @@
 # Demo of rest-server with prometheus and grafana
-version: '2'
 
 services:
   restserver:


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rest-server! Please
fill out the following questions to make it easier for us to review your
changes.
-->

Description
-----------------------------------------------------
We should remove the `version` tag in the docker-compose.yml, as it is deprecated as described in https://github.com/compose-spec/compose-spec/blob/main/spec.md#version-top-level-element-obsolete

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Not that I know of.

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/rest-server/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I'm done! This pull request is ready for review.
