### PR TITLE
Add --trust-proxy option for reverse proxy headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Flags:
       --tls-cert string              TLS certificate path
       --tls-key string               TLS key path
       --tls-min-ver string           TLS min version, one of (1.2|1.3) (default "1.2")
+      --trust-proxy                  trust proxy headers such as X-Forwarded-For (use when running behind a reverse proxy)
   -v, --version                      version for rest-server
 ```
 

--- a/cmd/rest-server/main.go
+++ b/cmd/rest-server/main.go
@@ -74,6 +74,7 @@ func newRestServerApp() *restServerApp {
 	flags.BoolVar(&rv.Server.Prometheus, "prometheus", rv.Server.Prometheus, "enable Prometheus metrics")
 	flags.BoolVar(&rv.Server.PrometheusNoAuth, "prometheus-no-auth", rv.Server.PrometheusNoAuth, "disable auth for Prometheus /metrics endpoint")
 	flags.BoolVar(&rv.Server.GroupAccessibleRepos, "group-accessible-repos", rv.Server.GroupAccessibleRepos, "let filesystem group be able to access repo files")
+	flags.BoolVar(&rv.Server.TrustProxy, "trust-proxy", rv.Server.TrustProxy, "trust proxy headers such as X-Forwarded-For (use when running behind a reverse proxy)")
 
 	return rv
 }
@@ -162,6 +163,12 @@ func (app *restServerApp) runRoot(_ *cobra.Command, _ []string) error {
 		log.Println("Group accessible repos enabled")
 	} else {
 		log.Println("Group accessible repos disabled")
+	}
+
+	if app.Server.TrustProxy {
+		log.Println("Trust proxy headers enabled")
+	} else {
+		log.Println("Trust proxy headers disabled")
 	}
 
 	enabledTLS, privateKey, publicKey, err := app.tlsSettings()

--- a/handlers.go
+++ b/handlers.go
@@ -35,6 +35,7 @@ type Server struct {
 	PanicOnError         bool
 	NoVerifyUpload       bool
 	GroupAccessibleRepos bool
+	TrustProxy           bool
 
 	htpasswdFile *HtpasswdFile
 	quotaManager *quota.Manager

--- a/mux.go
+++ b/mux.go
@@ -21,6 +21,10 @@ func (s *Server) debugHandler(next http.Handler) http.Handler {
 		})
 }
 
+func (s *Server) proxyHandler(next http.Handler) http.Handler {
+	return handlers.ProxyHeaders(next)
+}
+
 func (s *Server) logHandler(next http.Handler) http.Handler {
 	var accessLog io.Writer
 
@@ -110,6 +114,9 @@ func NewHandler(server *Server) (http.Handler, error) {
 	var handler http.Handler = mux
 	if server.Debug {
 		handler = server.debugHandler(handler)
+	}
+	if server.TrustProxy {
+		handler = server.proxyHandler(handler)
 	}
 	if server.Log != "" {
 		handler = server.logHandler(handler)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Adds a `--trust-proxy` option.

Logs show the real client IP instead of the proxy's IP address.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

yes, #233

Checklist
---------

- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
