### PR TITLE
properly close file in error handling of saveConfig and saveBlob

### DIFF
--- a/repo/repo.go
+++ b/repo/repo.go
@@ -315,6 +315,7 @@ func (h *Handler) saveConfig(w http.ResponseWriter, r *http.Request) {
 
 	_, err = io.Copy(f, r.Body)
 	if err != nil {
+		_ = f.Close()
 		h.internalServerError(w, err)
 		return
 	}
@@ -589,6 +590,8 @@ func (h *Handler) saveBlob(w http.ResponseWriter, r *http.Request) {
 	// ensure this blob does not put us over the quota size limit (if there is one)
 	outFile, errCode, err := h.wrapFileWriter(r, tf)
 	if err != nil {
+		_ = tf.Close()
+		_ = os.Remove(tf.Name())
 		if h.opt.Debug {
 			log.Println(err)
 		}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rest-server! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Fix two cases of file descriptor leaks:
- A file descriptor was leaked if `saveConfig` failed to write a file.
- A file descriptor and temp file was leaked if `saveBlob` exceeded the available quota.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Checked the code after https://github.com/restic/rest-server/issues/384 .
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/rest-server/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE)).
- [ ] I'm done! This pull request is ready for review.
