### PR TITLE
Docker: Use ENV key=value

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:alpine AS builder
 
-ENV CGO_ENABLED 0
+ENV CGO_ENABLED=0
 
 COPY . /build
 WORKDIR /build
@@ -11,8 +11,8 @@ RUN go build -o rest-server ./cmd/rest-server
 
 FROM alpine
 
-ENV DATA_DIRECTORY /data
-ENV PASSWORD_FILE /data/.htpasswd
+ENV DATA_DIRECTORY=/data
+ENV PASSWORD_FILE=/data/.htpasswd
 
 RUN apk add --no-cache --update apache2-utils tzdata
 

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,7 +1,7 @@
 FROM alpine
 
-ENV DATA_DIRECTORY /data
-ENV PASSWORD_FILE /data/.htpasswd
+ENV DATA_DIRECTORY=/data
+ENV PASSWORD_FILE=/data/.htpasswd
 
 RUN apk add --no-cache --update apache2-utils
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Use format "ENV key=value" in dockerfiles instead of legacy "ENV key value" format.
Before these change, an error message was displayed during build
```
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 3)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 11)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 12)
 ```

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No

Checklist
---------

- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
