### PR TITLE
Fix link to contribution guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,7 +32,7 @@ check the last box. Enable a checkbox by replacing [ ] with [x].
 Please always follow these steps:
 - Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
 - Run `gofmt` on the code in all commits.
-- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/rest-server/blob/master/CONTRIBUTING.md#git-commits).
+- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
 -->
 
 - [ ] I have added tests for all code changes.


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

The link in the PULL_REQUEST_TEMPLATE.md pointed to a CONTRIBUTING.md in this repository, which does not exist. It was introduced when the pull request template was synced with restic in commit 13f4617, which rewrote the URL from restic/restic to rest-server. Point it back at the restic repository.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Not to my knowledge

Checklist
---------

- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
